### PR TITLE
Deprecate legacy `\html-*` directives

### DIFF
--- a/include/cowel/builtin_directive_set.hpp
+++ b/include/cowel/builtin_directive_set.hpp
@@ -470,7 +470,7 @@ public:
     operator()(Content_Policy& out, const ast::Directive& d, Context& context) const override;
 
     [[nodiscard]]
-    virtual std::u8string_view get_name(const ast::Directive& d) const
+    virtual std::u8string_view get_name(const ast::Directive& d, Context& context) const
         = 0;
 };
 
@@ -567,7 +567,7 @@ public:
     }
 
     [[nodiscard]]
-    std::u8string_view get_name(const ast::Directive& d) const override;
+    std::u8string_view get_name(const ast::Directive& d, Context& context) const override;
 };
 
 struct Fixed_Name_Passthrough_Behavior : Passthrough_Behavior {
@@ -587,7 +587,7 @@ public:
     }
 
     [[nodiscard]]
-    std::u8string_view get_name(const ast::Directive&) const override
+    std::u8string_view get_name(const ast::Directive&, Context&) const override
     {
         return m_name;
     }

--- a/src/main/cpp/directives/passthrough.cpp
+++ b/src/main/cpp/directives/passthrough.cpp
@@ -181,8 +181,14 @@ In_Tag_Behavior::operator()(Content_Policy& out, const ast::Directive& d, Contex
 
 [[nodiscard]]
 std::u8string_view
-Directive_Name_Passthrough_Behavior::get_name(const ast::Directive& d, Context&) const
+Directive_Name_Passthrough_Behavior::get_name(const ast::Directive& d, Context& context) const
 {
+    context.try_warning(
+        diagnostic::deprecated, d.get_source_span(),
+        u8"\\html-NAME directives are deprecated. "
+        u8"Use \\cowel_html_element[NAME] instead."sv
+    );
+
     const std::u8string_view raw_name = d.get_name();
     const std::u8string_view name
         = raw_name.starts_with(builtin_directive_prefix) ? raw_name.substr(1) : raw_name;

--- a/src/main/cpp/directives/passthrough.cpp
+++ b/src/main/cpp/directives/passthrough.cpp
@@ -65,7 +65,7 @@ Passthrough_Behavior::operator()(Content_Policy& out, const ast::Directive& d, C
     HTML_Content_Policy html_policy { out };
     auto& policy = m_policy == Policy_Usage::html ? html_policy : out;
 
-    const std::u8string_view name = get_name(d);
+    const std::u8string_view name = get_name(d, context);
     HTML_Writer writer { policy };
     Attribute_Writer attributes = writer.open_tag_with_attributes(name);
     const auto attributes_status = named_arguments_to_attributes(attributes, d, context);
@@ -180,7 +180,8 @@ In_Tag_Behavior::operator()(Content_Policy& out, const ast::Directive& d, Contex
 }
 
 [[nodiscard]]
-std::u8string_view Directive_Name_Passthrough_Behavior::get_name(const ast::Directive& d) const
+std::u8string_view
+Directive_Name_Passthrough_Behavior::get_name(const ast::Directive& d, Context&) const
 {
     const std::u8string_view raw_name = d.get_name();
     const std::u8string_view name

--- a/src/test/cpp/test_document_generation.cpp
+++ b/src/test/cpp/test_document_generation.cpp
@@ -354,6 +354,11 @@ constexpr Basic_Test basic_tests[] {
       Processing_Status::error,
       { diagnostic::directive_lookup_unresolved } },
 
+    { Source { u8"\\html-div" },
+      Source { u8"<div></div>" },
+      Processing_Status::ok,
+      { diagnostic::deprecated } },
+
     { Source { u8"\\cowel_html_element[div]" },
       Source { u8"<div></div>" } },
 


### PR DESCRIPTION
Closes #29.