### PR TITLE
Add deprecation warning for hyphenated directive names in `\cowel_include`d content

### DIFF
--- a/docs/directives/chars.cow
+++ b/docs/directives/chars.cow
@@ -89,8 +89,8 @@ Note that U+0078 is the usual way in which Unicode code points are represented.
 That is, \tt{U+}, followed by at least four hexadecimal digits.
 It is also possible to define a macro if we need this frequently:
 \codeblock[cowel]{\literally{
-\macro[\code-point]{U+\Udigits{\put}}
-\code-point{x}
+\macro[\code_point]{U+\Udigits{\put}}
+\code_point{x}
 }}
 }
 
@@ -99,8 +99,8 @@ It is also possible to define a macro if we need this frequently:
 to produce human-readable descriptions of code points,
 while also keeping our source code readable:
 \codeblock[cowel]{\literally{
-\macro[\named-char{...}]{U+\Udigits[4]{\N{\put}} \put}
-\named-char{SECTION SIGN}
+\macro[\named_char{...}]{U+\Udigits[4]{\N{\put}} \put}
+\named_char{SECTION SIGN}
 }}
 This renders as:
 \Bindent{

--- a/docs/index.html
+++ b/docs/index.html
@@ -3501,16 +3501,16 @@ U+0078
 <p>Note that U+0078 is the usual way in which Unicode code points are represented.
 That is, <tt->U+</tt->, followed by at least four hexadecimal digits.
 It is also possible to define a macro if we need this frequently:
-</p><code-block><h- data-h=mk_tag>\macro</h-><h- data-h=sym_sqr>[</h-><h- data-h=mk_tag>\code-point</h-><h- data-h=sym_sqr>]</h-><h- data-h=sym_brac>{</h->U+<h- data-h=mk_tag>\Udigits</h-><h- data-h=sym_brac>{</h-><h- data-h=mk_tag>\put</h-><h- data-h=sym_brac>}</h-><h- data-h=sym_brac>}</h->
-<h- data-h=mk_tag>\code-point</h-><h- data-h=sym_brac>{</h->x<h- data-h=sym_brac>}</h-></code-block>
+</p><code-block><h- data-h=mk_tag>\macro</h-><h- data-h=sym_sqr>[</h-><h- data-h=mk_tag>\code_point</h-><h- data-h=sym_sqr>]</h-><h- data-h=sym_brac>{</h->U+<h- data-h=mk_tag>\Udigits</h-><h- data-h=sym_brac>{</h-><h- data-h=mk_tag>\put</h-><h- data-h=sym_brac>}</h-><h- data-h=sym_brac>}</h->
+<h- data-h=mk_tag>\code_point</h-><h- data-h=sym_brac>{</h->x<h- data-h=sym_brac>}</h-></code-block>
 </example-block>
 
 <tip-block><p><intro-></intro-> 
 <code><h- data-h=mk_tag>\Udigits</h-></code> can also be combined with <code><h- data-h=mk_tag>\N</h-></code>
 to produce human-readable descriptions of code points,
 while also keeping our source code readable:
-</p><code-block><h- data-h=mk_tag>\macro</h-><h- data-h=sym_sqr>[</h-><h- data-h=mk_tag>\named-char</h-><h- data-h=sym_brac>{</h->...<h- data-h=sym_brac>}</h-><h- data-h=sym_sqr>]</h-><h- data-h=sym_brac>{</h->U+<h- data-h=mk_tag>\Udigits</h-><h- data-h=sym_sqr>[</h->4<h- data-h=sym_sqr>]</h-><h- data-h=sym_brac>{</h-><h- data-h=mk_tag>\N</h-><h- data-h=sym_brac>{</h-><h- data-h=mk_tag>\put</h-><h- data-h=sym_brac>}</h-><h- data-h=sym_brac>}</h-> <h- data-h=mk_tag>\put</h-><h- data-h=sym_brac>}</h->
-<h- data-h=mk_tag>\named-char</h-><h- data-h=sym_brac>{</h->SECTION SIGN<h- data-h=sym_brac>}</h-></code-block>
+</p><code-block><h- data-h=mk_tag>\macro</h-><h- data-h=sym_sqr>[</h-><h- data-h=mk_tag>\named_char</h-><h- data-h=sym_brac>{</h->...<h- data-h=sym_brac>}</h-><h- data-h=sym_sqr>]</h-><h- data-h=sym_brac>{</h->U+<h- data-h=mk_tag>\Udigits</h-><h- data-h=sym_sqr>[</h->4<h- data-h=sym_sqr>]</h-><h- data-h=sym_brac>{</h-><h- data-h=mk_tag>\N</h-><h- data-h=sym_brac>{</h-><h- data-h=mk_tag>\put</h-><h- data-h=sym_brac>}</h-><h- data-h=sym_brac>}</h-> <h- data-h=mk_tag>\put</h-><h- data-h=sym_brac>}</h->
+<h- data-h=mk_tag>\named_char</h-><h- data-h=sym_brac>{</h->SECTION SIGN<h- data-h=sym_brac>}</h-></code-block>
 <p>This renders as:
 </p><div class=indent>
 U+00A7 SECTION SIGN

--- a/include/cowel/directive_processing.hpp
+++ b/include/cowel/directive_processing.hpp
@@ -194,6 +194,11 @@ void warn_ignored_argument_subset(
     Argument_Subset ignored_subset
 );
 
+/// @brief Emits a warning when directive names containing hyphens are found within `content`.
+/// Those are deprecated.
+/// The search is recursive for the arguments and content of any directive in `content`.
+void warn_deprecated_directive_names(std::span<const ast::Content> content, Context& context);
+
 using Argument_Filter = Function_Ref<bool(std::size_t index, const ast::Argument& argument) const>;
 
 [[nodiscard]]

--- a/src/main/cpp/directive_processing.cpp
+++ b/src/main/cpp/directive_processing.cpp
@@ -261,6 +261,24 @@ void warn_ignored_argument_subset(
     }
 }
 
+void warn_deprecated_directive_names(std::span<const ast::Content> content, Context& context)
+{
+    for (const ast::Content& c : content) {
+        if (const auto* const d = std::get_if<ast::Directive>(&c)) {
+            if (d->get_name().contains(u8'-')) {
+                context.try_warning(
+                    diagnostic::deprecated, d->get_name_span(),
+                    u8"The use of '-' in directive names is deprecated."sv
+                );
+            }
+            for (const ast::Argument& arg : d->get_arguments()) {
+                warn_deprecated_directive_names(arg.get_content(), context);
+            }
+            warn_deprecated_directive_names(d->get_content(), context);
+        }
+    }
+}
+
 Processing_Status named_arguments_to_attributes(
     Attribute_Writer& out,
     const ast::Directive& d,

--- a/src/main/cpp/directives/files.cpp
+++ b/src/main/cpp/directives/files.cpp
@@ -120,6 +120,8 @@ Include_Behavior::operator()(Content_Policy& out, const ast::Directive& d, Conte
     const std::pmr::vector<ast::Content> imported_content
         = parse_and_build(entry->source, entry->id, context.get_transient_memory(), on_error);
 
+    warn_deprecated_directive_names(imported_content, context);
+
     try_inherit_paragraph(out);
     return consume_all(out, imported_content, context);
 }

--- a/src/main/cpp/document_generation.cpp
+++ b/src/main/cpp/document_generation.cpp
@@ -140,25 +140,6 @@ bool Reference_Resolver::operator()(std::u8string_view text, File_Id file)
     return success;
 }
 
-[[maybe_unused]]
-void warn_deprecated_directive_names(std::span<const ast::Content> content, Context& context)
-{
-    for (const ast::Content& c : content) {
-        if (const auto* const d = std::get_if<ast::Directive>(&c)) {
-            if (d->get_name().contains(u8'-')) {
-                context.try_warning(
-                    diagnostic::deprecated, d->get_name_span(),
-                    u8"The use of '-' in directive names is deprecated."sv
-                );
-            }
-            for (const ast::Argument& arg : d->get_arguments()) {
-                warn_deprecated_directive_names(arg.get_content(), context);
-            }
-            warn_deprecated_directive_names(d->get_content(), context);
-        }
-    }
-}
-
 } // namespace
 
 Processing_Status write_head_body_document(


### PR DESCRIPTION
Fixes #40.