### PR TITLE
Simplify `Char_Sequence` constructor/`as_contiguous`

### DIFF
--- a/include/cowel/util/static_string.hpp
+++ b/include/cowel/util/static_string.hpp
@@ -15,6 +15,8 @@ namespace cowel {
 template <char_like Char, std::size_t capacity>
 struct Basic_Static_String {
     using array_type = std::array<Char, capacity>;
+    using iterator = array_type::iterator;
+    using const_iterator = array_type::const_iterator;
 
 private:
     array_type m_buffer {};
@@ -75,27 +77,25 @@ public:
     }
 
     [[nodiscard]]
-    constexpr typename array_type::iterator begin() noexcept
+    constexpr iterator begin() noexcept
+    {
+        return m_buffer.begin();
+    }
+    [[nodiscard]]
+    constexpr const_iterator begin() const noexcept
     {
         return m_buffer.begin();
     }
 
     [[nodiscard]]
-    constexpr typename array_type::const_iterator begin() const noexcept
+    constexpr iterator end() noexcept
     {
-        return m_buffer.begin();
+        return m_buffer.begin() + std::ptrdiff_t(m_length);
     }
-
     [[nodiscard]]
-    constexpr typename array_type::iterator end() noexcept
+    constexpr const_iterator end() const noexcept
     {
-        return m_buffer.end();
-    }
-
-    [[nodiscard]]
-    constexpr typename array_type::const_iterator end() const noexcept
-    {
-        return m_buffer.end();
+        return m_buffer.begin() + std::ptrdiff_t(m_length);
     }
 
     constexpr void remove_prefix(std::size_t n)


### PR DESCRIPTION
We don't actually need extract_from_static_string to be a function template. We can simply pad shorter Static_String with zeroes so that Char_Sequence only needs to consider the maximum-capacity Static_String case.

This change seems too small to be worth a CHANGELOG entry.