### PR TITLE
Add infinity literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@
   - `Csub` (use `cowel_sub` instead)
   - `Cmul` (use `cowel_mul` instead)
   - `Cdiv` (use `cowel_div_to_zero` instead)
-- change the syntax of directive arguments (#87)
-- add support for typed values in builtin directives (#88, #107)
+- change the syntax of directive arguments (#87, #107, #109, #111, #112)
+  - there are now values/literals of specific types
+  - only specific strings are allowed to be unquoted, rather than this being the default
+- add support for typed values in builtin directives (#88)
 - add the following basic arithmetic directives (#98):
   - `cowel_pos` (`+`)
   - `cowel_neg` (`-`)

--- a/docs/index.html
+++ b/docs/index.html
@@ -2033,6 +2033,9 @@ a <g-term>document</g-term> is constructed as follows:
 <h- data-h=name_nt_decl>int-literal</h->
   <h- data-h=sym_punc>=</h-> <h- data-h=sym_sqr>[</h-> <h- data-h=str_dlim>"</h-><h- data-h=str>-</h-><h- data-h=str_dlim>"</h-> <h- data-h=sym_sqr>]</h-><h- data-h=sym_op>,</h-> <h- data-h=name_nt>digit</h-><h- data-h=sym_op>,</h-> <h- data-h=sym_brac>{</h-> <h- data-h=name_nt>digit</h-> <h- data-h=sym_brac>}</h-><h- data-h=sym_punc>;</h->
 <h- data-h=name_nt_decl>float-literal</h->
+  <h- data-h=sym_punc>=</h-> <h- data-h=sym_sqr>[</h-> <h- data-h=str_dlim>"</h-><h- data-h=str>-</h-><h- data-h=str_dlim>"</h-> <h- data-h=sym_sqr>]</h-><h- data-h=sym_op>,</h-> <h- data-h=str_dlim>"</h-><h- data-h=str>infinity</h-><h- data-h=str_dlim>"</h->
+  <h- data-h=sym_op>|</h-> <h- data-h=name_nt>decimal-float-literal</h-><h- data-h=sym_punc>;</h->
+<h- data-h=name_nt_decl>decimal-float-literal</h->
   <h- data-h=sym_punc>=</h-> <h- data-h=sym_sqr>[</h-> <h- data-h=str_dlim>"</h-><h- data-h=str>-</h-><h- data-h=str_dlim>"</h-> <h- data-h=sym_sqr>]</h-><h- data-h=sym_op>,</h-> <h- data-h=name_nt>digit</h-><h- data-h=sym_op>,</h-> <h- data-h=sym_brac>{</h-> <h- data-h=name_nt>digit</h-> <h- data-h=sym_brac>}</h-><h- data-h=sym_op>,</h-> <h- data-h=str_dlim>"</h-><h- data-h=str>.</h-><h- data-h=str_dlim>"</h-><h- data-h=sym_op>,</h-> <h- data-h=sym_brac>{</h-> <h- data-h=name_nt>digit</h-> <h- data-h=sym_brac>}</h-><h- data-h=sym_op>,</h-> <h- data-h=sym_sqr>[</h-> <h- data-h=name_nt>exponent</h-> <h- data-h=sym_sqr>]</h->
   <h- data-h=sym_op>|</h-> <h- data-h=sym_sqr>[</h-> <h- data-h=str_dlim>"</h-><h- data-h=str>-</h-><h- data-h=str_dlim>"</h-> <h- data-h=sym_sqr>]</h-><h- data-h=sym_op>,</h-> <h- data-h=str_dlim>"</h-><h- data-h=str>.</h-><h- data-h=str_dlim>"</h-><h- data-h=sym_op>,</h-> <h- data-h=name_nt>digit</h-><h- data-h=sym_op>,</h-> <h- data-h=sym_brac>{</h-> <h- data-h=name_nt>digit</h-> <h- data-h=sym_brac>}</h-><h- data-h=sym_op>,</h-> <h- data-h=sym_sqr>[</h-> <h- data-h=name_nt>exponent</h-> <h- data-h=sym_sqr>]</h->
   <h- data-h=sym_op>|</h-> <h- data-h=sym_sqr>[</h-> <h- data-h=str_dlim>"</h-><h- data-h=str>-</h-><h- data-h=str_dlim>"</h-> <h- data-h=sym_sqr>]</h-><h- data-h=sym_op>,</h-> <h- data-h=name_nt>digit</h-><h- data-h=sym_op>,</h-> <h- data-h=sym_brac>{</h-> <h- data-h=name_nt>digit</h-> <h- data-h=sym_brac>}</h-><h- data-h=sym_op>,</h-> <h- data-h=name_nt>exponent</h-><h- data-h=sym_punc>;</h->
@@ -2603,6 +2606,9 @@ The <g-term>int-literal</g-term> <code>-0123</code> represents the integer value
 <h4 id=float-literal><a class=para href=#float-literal></a>4.6.2. <g-term>float-literal</g-term> — Floating-point literal</h4>
 
 <code-block><h- data-h=name_nt_decl>float-literal</h->
+  <h- data-h=sym_punc>=</h-> <h- data-h=sym_sqr>[</h-> <h- data-h=str_dlim>"</h-><h- data-h=str>-</h-><h- data-h=str_dlim>"</h-> <h- data-h=sym_sqr>]</h-><h- data-h=sym_op>,</h-> <h- data-h=str_dlim>"</h-><h- data-h=str>infinity</h-><h- data-h=str_dlim>"</h->
+  <h- data-h=sym_op>|</h-> <h- data-h=name_nt>decimal-float-literal</h-><h- data-h=sym_punc>;</h->
+<h- data-h=name_nt_decl>decimal-float-literal</h->
   <h- data-h=sym_punc>=</h-> <h- data-h=sym_sqr>[</h-> <h- data-h=str_dlim>"</h-><h- data-h=str>-</h-><h- data-h=str_dlim>"</h-> <h- data-h=sym_sqr>]</h-><h- data-h=sym_op>,</h-> <h- data-h=name_nt>digit</h-><h- data-h=sym_op>,</h-> <h- data-h=sym_brac>{</h-> <h- data-h=name_nt>digit</h-> <h- data-h=sym_brac>}</h-><h- data-h=sym_op>,</h-> <h- data-h=str_dlim>"</h-><h- data-h=str>.</h-><h- data-h=str_dlim>"</h-><h- data-h=sym_op>,</h-> <h- data-h=sym_brac>{</h-> <h- data-h=name_nt>digit</h-> <h- data-h=sym_brac>}</h-><h- data-h=sym_op>,</h-> <h- data-h=sym_sqr>[</h-> <h- data-h=name_nt>exponent</h-> <h- data-h=sym_sqr>]</h->
   <h- data-h=sym_op>|</h-> <h- data-h=sym_sqr>[</h-> <h- data-h=str_dlim>"</h-><h- data-h=str>-</h-><h- data-h=str_dlim>"</h-> <h- data-h=sym_sqr>]</h-><h- data-h=sym_op>,</h-> <h- data-h=str_dlim>"</h-><h- data-h=str>.</h-><h- data-h=str_dlim>"</h-><h- data-h=sym_op>,</h-> <h- data-h=name_nt>digit</h-><h- data-h=sym_op>,</h-> <h- data-h=sym_brac>{</h-> <h- data-h=name_nt>digit</h-> <h- data-h=sym_brac>}</h-><h- data-h=sym_op>,</h-> <h- data-h=sym_sqr>[</h-> <h- data-h=name_nt>exponent</h-> <h- data-h=sym_sqr>]</h->
   <h- data-h=sym_op>|</h-> <h- data-h=sym_sqr>[</h-> <h- data-h=str_dlim>"</h-><h- data-h=str>-</h-><h- data-h=str_dlim>"</h-> <h- data-h=sym_sqr>]</h-><h- data-h=sym_op>,</h-> <h- data-h=name_nt>digit</h-><h- data-h=sym_op>,</h-> <h- data-h=sym_brac>{</h-> <h- data-h=name_nt>digit</h-> <h- data-h=sym_brac>}</h-><h- data-h=sym_op>,</h-> <h- data-h=name_nt>exponent</h-><h- data-h=sym_punc>;</h->
@@ -2612,7 +2618,10 @@ The <g-term>int-literal</g-term> <code>-0123</code> represents the integer value
 <p>A <g-term>float-literal</g-term> represents a value of type <tt-><h- data-h=kw_type>float</h-></tt->
 (<a href=#type-float>§6.2.7. <tt-><h- data-h=kw_type>float</h-></tt-> — 64-bit floating-point number</a>).
 </p>
-<p>A <g-term>float-literal</g-term> consists of several parts:
+<p>The value of '<tt->-infinity</tt->' is negative infinity, and
+the value of '<tt->infinity</tt->' is positive infinity.
+</p>
+<p>A <g-term>decimal-float-literal</g-term> consists of several parts:
 </p><ul>
   <li>
     An <dfn>integral part</dfn>, either matching a <g-term>int-literal</g-term>
@@ -2631,7 +2640,7 @@ The <g-term>int-literal</g-term> <code>-0123</code> represents the integer value
   </li>
 </ul>
 
-<p>The value of a <g-term>float-literal</g-term> is determined as follows:
+<p>The value of a <g-term>decimal-float-literal</g-term> is determined as follows:
 </p>
 <ol>
   <li>
@@ -2644,7 +2653,7 @@ The <g-term>int-literal</g-term> <code>-0123</code> represents the integer value
     let <math display=inline><mi>e</mi></math> be the integer value of the exponent.
   </li>
   <li>
-    Let the <dfn>scaled value</dfn> of the <g-term>float-literal</g-term> be
+    Let the <dfn>scaled value</dfn> of the <g-term>decimal-float-literal</g-term> be
     <math display=block><mrow>
       <mi>s</mi>
       <mo>×</mo>
@@ -2658,7 +2667,7 @@ The <g-term>int-literal</g-term> <code>-0123</code> represents the integer value
     </mrow></math>
   </li>
   <li>
-    The value of the <g-term>float-literal</g-term> is the scaled value,
+    The value of the <g-term>decimal-float-literal</g-term> is the scaled value,
     rounded using the roundTiesToEven rounding direction
     as specified in IEEE-754.
   </li>

--- a/docs/intro/grammar.ebnf
+++ b/docs/intro/grammar.ebnf
@@ -73,6 +73,9 @@ bool-literal
 int-literal
   = [ "-" ], digit, { digit };
 float-literal
+  = [ "-" ], "infinity"
+  | decimal-float-literal;
+decimal-float-literal
   = [ "-" ], digit, { digit }, ".", { digit }, [ exponent ]
   | [ "-" ], ".", digit, { digit }, [ exponent ]
   | [ "-" ], digit, { digit }, exponent;

--- a/docs/intro/syntax.cow
+++ b/docs/intro/syntax.cow
@@ -606,6 +606,9 @@ The \gterm{int-literal} \cowdoc_c{-0123} represents the integer value -123.
 
 \codeblock(ebnf){
 float-literal
+  = [ "-" ], "infinity"
+  | decimal-float-literal;
+decimal-float-literal
   = [ "-" ], digit, { digit }, ".", { digit }, [ exponent ]
   | [ "-" ], ".", digit, { digit }, [ exponent ]
   | [ "-" ], digit, { digit }, exponent;
@@ -616,7 +619,10 @@ exponent
 A \gterm{float-literal} represents a value of type \cowdoc_type{float}
 (\ref("#type-float")).
 
-A \gterm{float-literal} consists of several parts:
+The value of '\tt{-infinity}' is negative infinity, and
+the value of '\tt{infinity}' is positive infinity.
+
+A \gterm{decimal-float-literal} consists of several parts:
 \ul{
   \li{
     An \dfn{integral part}, either matching a \gterm{int-literal}
@@ -635,7 +641,7 @@ A \gterm{float-literal} consists of several parts:
   }
 }
 
-The value of a \gterm{float-literal} is determined as follows:
+The value of a \gterm{decimal-float-literal} is determined as follows:
 
 \ol{
   \li{
@@ -648,7 +654,7 @@ The value of a \gterm{float-literal} is determined as follows:
     let \math{\mi{e}} be the integer value of the exponent.
   }
   \li{
-    Let the \dfn{scaled value} of the \gterm{float-literal} be
+    Let the \dfn{scaled value} of the \gterm{decimal-float-literal} be
     \mathblock{\mrow{
       \mi{s}
       \mo{×}
@@ -662,7 +668,7 @@ The value of a \gterm{float-literal} is determined as follows:
     }}
   }
   \li{
-    The value of the \gterm{float-literal} is the scaled value,
+    The value of the \gterm{decimal-float-literal} is the scaled value,
     rounded using the roundTiesToEven rounding direction
     as specified in IEEE-754.
   }

--- a/include/cowel/ast.hpp
+++ b/include/cowel/ast.hpp
@@ -30,11 +30,12 @@ template <typename T>
 using Pmr_Vector = std::vector<T, Propagated_Polymorphic_Allocator<T>>;
 
 enum struct Primary_Kind : Default_Underlying {
-    unit,
-    null,
-    boolean,
-    integer,
-    floating_point,
+    unit_literal,
+    null_literal,
+    bool_literal,
+    int_literal,
+    decimal_float_literal,
+    infinity,
     unquoted_string,
     text,
     escape,
@@ -54,11 +55,12 @@ constexpr bool primary_kind_is_value(Primary_Kind kind)
 {
     using enum Primary_Kind;
     switch (kind) {
-    case unit:
-    case null:
-    case boolean:
-    case integer:
-    case floating_point:
+    case unit_literal:
+    case null_literal:
+    case bool_literal:
+    case int_literal:
+    case decimal_float_literal:
+    case infinity:
     case unquoted_string:
     case block:
     case quoted_string:
@@ -77,11 +79,12 @@ constexpr bool primary_kind_is_spliceable(Primary_Kind kind)
 {
     using enum Primary_Kind;
     switch (kind) {
-    case unit:
-    case null:
-    case boolean:
-    case integer:
-    case floating_point:
+    case unit_literal:
+    case null_literal:
+    case bool_literal:
+    case int_literal:
+    case decimal_float_literal:
+    case infinity:
     case unquoted_string:
     case quoted_string:
     case block:
@@ -106,11 +109,12 @@ constexpr std::u8string_view primary_kind_display_name(Primary_Kind kind)
 {
     using enum Primary_Kind;
     switch (kind) {
-    case unit: return u8"unit";
-    case null: return u8"null";
-    case boolean: return u8"boolean literal";
-    case integer: return u8"integer literal";
-    case floating_point: return u8"floating-point literal";
+    case unit_literal: return u8"unit";
+    case null_literal: return u8"null";
+    case bool_literal: return u8"boolean literal";
+    case int_literal: return u8"integer literal";
+    case decimal_float_literal: return u8"floating-point literal";
+    case infinity: return u8"infinity";
     case unquoted_string: return u8"unquoted string";
     case text: return u8"text";
     case escape: return u8"escape";

--- a/include/cowel/parse.hpp
+++ b/include/cowel/parse.hpp
@@ -38,6 +38,10 @@ enum struct AST_Instruction_Type : Default_Underlying {
     keyword_null,
     /// @brief The next `n` characters are `unit`.
     keyword_unit,
+    /// @brief The next `n` characters are `infinity`.
+    keyword_infinity,
+    /// @brief The next `n` characters are `-infinity`.
+    keyword_neg_infinity,
     /// @brief The next `n` characters are a comment,
     /// including the `\:` prefix and the terminating newline, if any.
     comment,

--- a/include/cowel/policy/html.hpp
+++ b/include/cowel/policy/html.hpp
@@ -97,11 +97,12 @@ public:
         case ast::Primary_Kind::comment: {
             break;
         }
-        case ast::Primary_Kind::unit:
-        case ast::Primary_Kind::null:
-        case ast::Primary_Kind::boolean:
-        case ast::Primary_Kind::integer:
-        case ast::Primary_Kind::floating_point:
+        case ast::Primary_Kind::unit_literal:
+        case ast::Primary_Kind::null_literal:
+        case ast::Primary_Kind::bool_literal:
+        case ast::Primary_Kind::int_literal:
+        case ast::Primary_Kind::decimal_float_literal:
+        case ast::Primary_Kind::infinity:
         case ast::Primary_Kind::unquoted_string:
         case ast::Primary_Kind::quoted_string:
         case ast::Primary_Kind::block:

--- a/include/cowel/policy/html_literal.hpp
+++ b/include/cowel/policy/html_literal.hpp
@@ -50,11 +50,12 @@ struct HTML_Literal_Content_Policy : virtual HTML_Content_Policy {
         case ast::Primary_Kind::comment: {
             break;
         }
-        case ast::Primary_Kind::unit:
-        case ast::Primary_Kind::null:
-        case ast::Primary_Kind::boolean:
-        case ast::Primary_Kind::integer:
-        case ast::Primary_Kind::floating_point:
+        case ast::Primary_Kind::unit_literal:
+        case ast::Primary_Kind::null_literal:
+        case ast::Primary_Kind::bool_literal:
+        case ast::Primary_Kind::int_literal:
+        case ast::Primary_Kind::decimal_float_literal:
+        case ast::Primary_Kind::infinity:
         case ast::Primary_Kind::unquoted_string:
         case ast::Primary_Kind::quoted_string:
         case ast::Primary_Kind::block:

--- a/include/cowel/policy/paragraph_split.hpp
+++ b/include/cowel/policy/paragraph_split.hpp
@@ -132,11 +132,12 @@ public:
             }
             break;
         }
-        case ast::Primary_Kind::unit:
-        case ast::Primary_Kind::null:
-        case ast::Primary_Kind::boolean:
-        case ast::Primary_Kind::integer:
-        case ast::Primary_Kind::floating_point:
+        case ast::Primary_Kind::unit_literal:
+        case ast::Primary_Kind::null_literal:
+        case ast::Primary_Kind::bool_literal:
+        case ast::Primary_Kind::int_literal:
+        case ast::Primary_Kind::decimal_float_literal:
+        case ast::Primary_Kind::infinity:
         case ast::Primary_Kind::unquoted_string:
         case ast::Primary_Kind::quoted_string:
         case ast::Primary_Kind::block:

--- a/include/cowel/policy/plaintext.hpp
+++ b/include/cowel/policy/plaintext.hpp
@@ -51,11 +51,12 @@ public:
         case ast::Primary_Kind::comment: {
             break;
         }
-        case ast::Primary_Kind::unit:
-        case ast::Primary_Kind::null:
-        case ast::Primary_Kind::boolean:
-        case ast::Primary_Kind::integer:
-        case ast::Primary_Kind::floating_point:
+        case ast::Primary_Kind::unit_literal:
+        case ast::Primary_Kind::null_literal:
+        case ast::Primary_Kind::bool_literal:
+        case ast::Primary_Kind::int_literal:
+        case ast::Primary_Kind::decimal_float_literal:
+        case ast::Primary_Kind::infinity:
         case ast::Primary_Kind::unquoted_string:
         case ast::Primary_Kind::quoted_string:
         case ast::Primary_Kind::block:

--- a/include/cowel/policy/syntax_highlight.hpp
+++ b/include/cowel/policy/syntax_highlight.hpp
@@ -80,11 +80,12 @@ public:
         case ast::Primary_Kind::comment: {
             break;
         }
-        case ast::Primary_Kind::unit:
-        case ast::Primary_Kind::null:
-        case ast::Primary_Kind::boolean:
-        case ast::Primary_Kind::integer:
-        case ast::Primary_Kind::floating_point:
+        case ast::Primary_Kind::unit_literal:
+        case ast::Primary_Kind::null_literal:
+        case ast::Primary_Kind::bool_literal:
+        case ast::Primary_Kind::int_literal:
+        case ast::Primary_Kind::decimal_float_literal:
+        case ast::Primary_Kind::infinity:
         case ast::Primary_Kind::unquoted_string:
         case ast::Primary_Kind::quoted_string:
         case ast::Primary_Kind::block:

--- a/src/main/cpp/build_ast.cpp
+++ b/src/main/cpp/build_ast.cpp
@@ -152,23 +152,27 @@ void Primary::assert_validity() const
     COWEL_ASSERT(m_source.length() == m_source_span.length);
 
     switch (m_kind) {
-    case Primary_Kind::unit: {
+    case Primary_Kind::unit_literal: {
         COWEL_ASSERT(m_source == u8"unit"sv);
         break;
     }
-    case Primary_Kind::null: {
+    case Primary_Kind::null_literal: {
         COWEL_ASSERT(m_source == u8"null"sv);
         break;
     }
-    case Primary_Kind::boolean: {
+    case Primary_Kind::bool_literal: {
         COWEL_ASSERT(m_source == u8"true"sv || m_source == u8"false"sv);
         break;
     }
-    case Primary_Kind::integer: {
+    case Primary_Kind::infinity: {
+        COWEL_ASSERT(m_source == u8"-infinity"sv || m_source == u8"infinity"sv);
+        break;
+    }
+    case Primary_Kind::int_literal: {
         COWEL_ASSERT(is_ascii_digit(m_source.at(0 + std::size_t(m_source.starts_with(u8'-')))));
         break;
     }
-    case Primary_Kind::floating_point:
+    case Primary_Kind::decimal_float_literal:
     case Primary_Kind::unquoted_string:
     case Primary_Kind::text: {
         break;
@@ -256,12 +260,14 @@ constexpr std::optional<ast::Primary_Kind> instruction_type_primary_kind(AST_Ins
     case escape: return ast::Primary_Kind::escape;
     case text: return ast::Primary_Kind::text;
     case unquoted_string: return ast::Primary_Kind::unquoted_string;
-    case decimal_int_literal: return ast::Primary_Kind::integer;
-    case float_literal: return ast::Primary_Kind::floating_point;
-    case keyword_unit: return ast::Primary_Kind::unit;
-    case keyword_null: return ast::Primary_Kind::null;
+    case decimal_int_literal: return ast::Primary_Kind::int_literal;
+    case float_literal: return ast::Primary_Kind::decimal_float_literal;
+    case keyword_unit: return ast::Primary_Kind::unit_literal;
+    case keyword_null: return ast::Primary_Kind::null_literal;
     case keyword_true:
-    case keyword_false: return ast::Primary_Kind::boolean;
+    case keyword_false: return ast::Primary_Kind::bool_literal;
+    case keyword_infinity:
+    case keyword_neg_infinity: return ast::Primary_Kind::infinity;
     case comment: return ast::Primary_Kind::comment;
     default: return {};
     }
@@ -551,6 +557,8 @@ private:
         case AST_Instruction_Type::keyword_null:
         case AST_Instruction_Type::keyword_true:
         case AST_Instruction_Type::keyword_false:
+        case AST_Instruction_Type::keyword_infinity:
+        case AST_Instruction_Type::keyword_neg_infinity:
         case AST_Instruction_Type::unquoted_string:
         case AST_Instruction_Type::decimal_int_literal:
         case AST_Instruction_Type::float_literal: {

--- a/src/main/cpp/directives/variables.cpp
+++ b/src/main/cpp/directives/variables.cpp
@@ -374,6 +374,20 @@ Unary_Numeric_Expression_Behavior::evaluate(const Invocation& call, Context& con
     const auto& first_value = group_matcher.get_values().front().value;
     const auto& first_type = first_value.get_type();
 
+    if (!first_type.analytically_convertible_to(numeric_type)) {
+        context.try_error(
+            diagnostic::type_mismatch, group_matcher.get_values().front().location,
+            joined_char_sequence({
+                u8"Expected a value of type "sv,
+                numeric_type.get_display_name(),
+                u8", but got "sv,
+                first_type.get_display_name(),
+                u8".",
+            })
+        );
+        return Processing_Status::error;
+    }
+
     switch (first_type.get_kind()) {
     case Type_Kind::integer: {
         return Value::integer(operate_unary(m_expression_kind, first_value.as_integer()));

--- a/src/main/cpp/parse.cpp
+++ b/src/main/cpp/parse.cpp
@@ -612,6 +612,16 @@ private:
             m_out.push_back({ AST_Instruction_Type::keyword_false, length });
             return true;
         }
+        if (match == u8"infinity"sv) {
+            advance_by(length);
+            m_out.push_back({ AST_Instruction_Type::keyword_infinity, length });
+            return true;
+        }
+        if (match == u8"-infinity"sv) {
+            advance_by(length);
+            m_out.push_back({ AST_Instruction_Type::keyword_neg_infinity, length });
+            return true;
+        }
 
         advance_by(length);
         m_out.push_back({ AST_Instruction_Type::unquoted_string, length });
@@ -725,6 +735,8 @@ std::u8string_view ast_instruction_type_name(AST_Instruction_Type type)
         COWEL_ENUM_STRING_CASE8(keyword_false);
         COWEL_ENUM_STRING_CASE8(keyword_null);
         COWEL_ENUM_STRING_CASE8(keyword_unit);
+        COWEL_ENUM_STRING_CASE8(keyword_infinity);
+        COWEL_ENUM_STRING_CASE8(keyword_neg_infinity);
         COWEL_ENUM_STRING_CASE8(comment);
         COWEL_ENUM_STRING_CASE8(member_name);
         COWEL_ENUM_STRING_CASE8(ellipsis);

--- a/test/splice/floats.cow
+++ b/test/splice/floats.cow
@@ -5,3 +5,6 @@
 \cowel_pos(1e5)
 \cowel_pos(1e-10)
 \cowel_pos(1e100)
+
+\cowel_pos(infinity)
+\cowel_pos(-infinity)

--- a/test/splice/floats.cow.html
+++ b/test/splice/floats.cow.html
@@ -5,3 +5,6 @@
 1e+5
 1e-10
 1e+100
+
+infinity
+-infinity


### PR DESCRIPTION
Closes #111.

This also includes some drive-by renames of various symbols to create more symmetry with the EBNF grammar. `infinity` is considered a *float-literal*, and the original *float-literal* is now a *decimal-float-literal*.