### PR TITLE
Refactor AST, remove `Generated` node

### DIFF
--- a/include/cowel/fwd.hpp
+++ b/include/cowel/fwd.hpp
@@ -85,7 +85,6 @@ namespace ast {
 struct Markup_Element;
 struct Member_Value;
 struct Directive;
-struct Generated;
 struct Group_Member;
 struct Primary;
 

--- a/include/cowel/policy/actions.hpp
+++ b/include/cowel/policy/actions.hpp
@@ -39,12 +39,6 @@ public:
     {
         return m_parent.consume(directive, frame, context);
     }
-    [[nodiscard]]
-    Processing_Status
-    consume(const ast::Generated& generated, Frame_Index frame, Context& context) override
-    {
-        return m_parent.consume(generated, frame, context);
-    }
 };
 
 } // namespace cowel

--- a/include/cowel/policy/content_policy.hpp
+++ b/include/cowel/policy/content_policy.hpp
@@ -65,10 +65,6 @@ struct Content_Policy : virtual Text_Sink {
     virtual Processing_Status //
     consume(const ast::Directive& directive, Frame_Index frame, Context& context)
         = 0;
-    [[nodiscard]]
-    virtual Processing_Status //
-    consume(const ast::Generated& generated, Frame_Index frame, Context&)
-        = 0;
 
     [[nodiscard]]
     Processing_Status //

--- a/include/cowel/policy/html.hpp
+++ b/include/cowel/policy/html.hpp
@@ -119,13 +119,6 @@ public:
     {
         return splice_directive_invocation(*this, directive, frame, context);
     }
-
-    [[nodiscard]]
-    Processing_Status consume(const ast::Generated& generated, Frame_Index, Context&) override
-    {
-        write(generated.as_string(), generated.get_type());
-        return Processing_Status::ok;
-    }
 };
 
 } // namespace cowel

--- a/include/cowel/policy/html_literal.hpp
+++ b/include/cowel/policy/html_literal.hpp
@@ -72,13 +72,6 @@ struct HTML_Literal_Content_Policy : virtual HTML_Content_Policy {
     {
         return splice_directive_invocation(*this, directive, frame, context);
     }
-
-    [[nodiscard]]
-    Processing_Status consume(const ast::Generated& generated, Frame_Index, Context&) override
-    {
-        write(generated.as_string(), generated.get_type());
-        return Processing_Status::ok;
-    }
 };
 
 } // namespace cowel

--- a/include/cowel/policy/ignorant.hpp
+++ b/include/cowel/policy/ignorant.hpp
@@ -36,11 +36,6 @@ struct Ignorant_Content_Policy : virtual Content_Policy {
     {
         return Processing_Status::ok;
     }
-    [[nodiscard]]
-    Processing_Status consume(const ast::Generated&, Frame_Index, Context&) override
-    {
-        return Processing_Status::ok;
-    }
 };
 
 } // namespace cowel

--- a/include/cowel/policy/literally.hpp
+++ b/include/cowel/policy/literally.hpp
@@ -1,8 +1,6 @@
 #ifndef COWEL_POLICY_LITERALLY_HPP
 #define COWEL_POLICY_LITERALLY_HPP
 
-#include "cowel/util/assert.hpp"
-
 #include "cowel/policy/plaintext.hpp"
 
 #include "cowel/content_status.hpp"
@@ -34,12 +32,6 @@ public:
     {
         write(directive.get_source(), Output_Language::text);
         return Processing_Status::ok;
-    }
-    [[nodiscard]]
-    Processing_Status consume(const ast::Generated&, Frame_Index, Context&) override
-    {
-        COWEL_ASSERT_UNREACHABLE(u8"Generated content within To_Source_Policy should be impossible."
-        );
     }
 };
 

--- a/include/cowel/policy/paragraph_split.hpp
+++ b/include/cowel/policy/paragraph_split.hpp
@@ -167,15 +167,6 @@ public:
         return splice_directive_invocation(*this, directive, frame, context);
     }
 
-    [[nodiscard]]
-    Processing_Status consume(const ast::Generated& generated, Frame_Index, Context&) override
-    {
-        // We deliberately don't update m_line_state here
-        // because paragraph splitting generally operates on syntactical elements.
-        write(generated.as_string(), generated.get_type());
-        return Processing_Status::ok;
-    }
-
     /// @brief Enables paragraph splitting to take place inside a directive.
     ///
     /// By default, directives are treated as black boxes,

--- a/include/cowel/policy/plaintext.hpp
+++ b/include/cowel/policy/plaintext.hpp
@@ -73,12 +73,6 @@ public:
     {
         return splice_directive_invocation(*this, directive, frame, context);
     }
-    [[nodiscard]]
-    Processing_Status consume(const ast::Generated& generated, Frame_Index, Context&) override
-    {
-        write(generated.as_string(), generated.get_type());
-        return Processing_Status::ok;
-    }
 };
 
 } // namespace cowel

--- a/include/cowel/policy/syntax_highlight.hpp
+++ b/include/cowel/policy/syntax_highlight.hpp
@@ -102,12 +102,6 @@ public:
     {
         return splice_directive_invocation(*this, directive, frame, context);
     }
-    [[nodiscard]]
-    Processing_Status consume(const ast::Generated& generated, Frame_Index, Context&) override
-    {
-        write(generated.as_string(), generated.get_type());
-        return Processing_Status::ok;
-    }
 
     /// @brief Writes pure HTML content to `out`,
     /// consisting of the received HTML content,

--- a/include/cowel/policy/unprocessed.hpp
+++ b/include/cowel/policy/unprocessed.hpp
@@ -1,8 +1,6 @@
 #ifndef COWEL_POLICY_UNPROCESSED_HPP
 #define COWEL_POLICY_UNPROCESSED_HPP
 
-#include "cowel/util/assert.hpp"
-
 #include "cowel/policy/content_policy.hpp"
 #include "cowel/policy/plaintext.hpp"
 
@@ -29,14 +27,6 @@ public:
     {
         write(directive.get_source(), Output_Language::text);
         return Processing_Status::ok;
-    }
-
-    [[nodiscard]]
-    Processing_Status consume(const ast::Generated&, Frame_Index, Context&) override
-    {
-        COWEL_ASSERT_UNREACHABLE(
-            u8"Generated content within Unprocessed_Content_Policy should be impossible."
-        );
     }
 };
 

--- a/src/main/cpp/directive_processing.cpp
+++ b/src/main/cpp/directive_processing.cpp
@@ -188,12 +188,6 @@ trim_blank_text_left(std::span<const ast::Markup_Element> content)
                 continue;
             }
         }
-        if (const auto* const text = content.front().try_as_generated()) {
-            if (is_ascii_blank(text->as_string())) {
-                content = content.subspan(1);
-                continue;
-            }
-        }
         break;
     }
     return content;
@@ -205,12 +199,6 @@ trim_blank_text_right(std::span<const ast::Markup_Element> content)
     while (!content.empty()) {
         if (const auto* const text = content.back().try_as_primary()) {
             if (text->get_kind() == ast::Primary_Kind::text && is_ascii_blank(text->get_source())) {
-                content = content.subspan(0, content.size() - 1);
-                continue;
-            }
-        }
-        if (const auto* const generated = content.back().try_as_generated()) {
-            if (is_ascii_blank(generated->as_string())) {
                 content = content.subspan(0, content.size() - 1);
                 continue;
             }
@@ -285,16 +273,6 @@ Processing_Status splice_all_trimmed(
             }
             write_trimmed(node.get_source());
             return Processing_Status::ok;
-        }
-
-        [[nodiscard]]
-        Processing_Status operator()(const ast::Generated& g) const
-        {
-            if (g.get_type() == Output_Language::text) {
-                write_trimmed(g.as_string());
-                return Processing_Status::ok;
-            }
-            return out.consume(g, frame, context);
         }
 
         [[nodiscard]]


### PR DESCRIPTION
This basically just removes dead code.

The point of `ast::Generated` was to represent programmatically created content, but having an AST node for this seems extremely wrong in the context of upcoming v0.7 languages changes.