### PR TITLE
Change `cowel_char_get_num` to a `str->int` directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - change the syntax of directive arguments (#87, #107, #109, #111, #112, #121)
   - there are now values/literals of specific types
   - only specific strings are allowed to be unquoted, rather than this being the default
+- change `cowel_char_*` directives as follows:
+  - `cowel_char_get_num` takes a `str` and returns an `int`
 - add support for typed values in builtin directives (#88)
 - add the following basic arithmetic directives (#98):
   - `cowel_pos` (`+`)

--- a/docs/directives/separators.cow
+++ b/docs/directives/separators.cow
@@ -52,6 +52,6 @@ You can insert these using
 \ul{
   \li{\cowdoc_c{Combined\\c{nbsp}Word},}
   \li{\cowdoc_c{Combined\\N{NO-BREAK SPACE}Word}, or}
-  \li{\cowdoc_c{Combined\\U{\Udigits{\N{NO-BREAK SPACE}}}Word}.}
+  \li{\cowdoc_c{Combined\\U{A0}Word}.}
 }
 }

--- a/docs/index.cow
+++ b/docs/index.cow
@@ -55,11 +55,6 @@ U+\cowel_put\c{nbsp}(\tt{\U{\cowel_put}})\
 \cowel_char_by_num(...){\cowel_put}\
 }
 
-\cowel_macro(Udigits){\
-\cowel_paragraph_enter\
-\cowel_char_get_num(...){\cowel_put}\
-}
-
 \cowel_macro(cowdoc_og_property){\
 \cowel_html_element(
   meta,

--- a/docs/index.html
+++ b/docs/index.html
@@ -3615,80 +3615,44 @@ they cannot easily tell what the purpose of the character is.
 <h4 id=dir-cowel_char_get_num><a class=para href=#dir-cowel_char_get_num></a>8.2.4. <code><h- data-h=mk_tag>\cowel_char_get_num</h-></code> — Get digits of character</h4>
 
 <pre>
-<h- data-h=mk_tag>cowel_char_get_num</h->(
-  <h- data-h=mk_attr>zfill</h->: <h- data-h=kw_type>bool</h-> = 0,
-  <h- data-h=mk_attr>base</h->: <h- data-h=kw_type>int</h-> = 16,
-  <h- data-h=mk_attr>lower</h->: <h- data-h=kw_type>bool</h-> = false,
-){...}: <h- data-h=kw_type>block</h->
+<h- data-h=mk_tag>cowel_char_get_num</h->(<h- data-h=mk_attr>x</h->: <h- data-h=kw_type>str</h->): <h- data-h=kw_type>int</h->
 </pre>
 
 <p>The <code><h- data-h=mk_tag>\cowel_char_get_num</h-></code> directive is essentially the
 inverse of the <code><h- data-h=mk_tag>\cowel_char_by_num</h-></code> directive.
-Its input is also plaintext content.
-Rather than producing a code point from a digit sequence,
-it produces a digit sequence from its input code point.
+It returns the numeric value of the first input code point in <tt-><h- data-h=mk_attr>x</h-></tt->.
 </p>
-<p>This can be fine-tuned with the following parameters:
-</p><dd>
-  <dt><tt-><h- data-h=mk_attr>zfill</h-></tt-></dt>
-  <dd>
-    The minimum amount of digits that should be produced.
-    This is an integer argument in range [0, 1024], and defaults to zero.
-    If the amount of digits is less than <tt-><h- data-h=mk_attr>zfill</h-></tt->,
-    it will be left-padded with additional '<tt->0</tt->' characters.
-  </dd>
-
-  <dt><tt-><h- data-h=mk_attr>base</h-></tt-></dt>
-  <dd>
-    The base of the output digit sequence, in range [2, 16].
-    This defaults to 16, meaning that the digits are printed in hexadecimal.
-  </dd>
-
-  <dt><tt-><h- data-h=mk_attr>lower</h-></tt-></dt>
-  <dd>
-    A yes/no plaintext argument, defaulting to <tt->no</tt->.
-    If <tt->yes</tt-> is specified, digits beyond '<tt->9</tt->' (i.e. '<tt->A</tt->' to '<tt->F</tt->')
-    will be output in lower case instead.
-</dd>
-</dd>
-
 <example-block><p><intro-></intro-> 
 COWEL markup:
-</p><code-block>U+<h- data-h=mk_tag>\cowel_char_get_num</h-><h- data-h=sym_par>(</h->4<h- data-h=sym_par>)</h-><h- data-h=sym_brac>{</h->x<h- data-h=sym_brac>}</h-></code-block>
-<p>This renders as:
-</p><div class=indent>
-U+0078
-</div>
+</p><code-block><h- data-h=mk_tag>\cowel_char_get_num</h-><h- data-h=sym_par>(</h->"x"<h- data-h=sym_par>)</h->
+U+<h- data-h=mk_tag>\cowel_to_str</h-><h- data-h=sym_par>(</h->cowel_char_get_num("x")<h- data-h=sym_punc>,</h-> <h- data-h=mk_attr>base</h-><h- data-h=sym_punc>=</h->16<h- data-h=sym_punc>,</h-> <h- data-h=mk_attr>zpad</h-><h- data-h=sym_punc>=</h->4<h- data-h=sym_par>)</h-></code-block>
+<p>Generated HTML:
+</p><code-block>120
+U+0078</code-block>
 <p>Note that U+0078 is the usual way in which Unicode code points are represented.
 That is, <tt->U+</tt->, followed by at least four hexadecimal digits.
 It is also possible to define a macro if we need this frequently:
-</p><code-block><h- data-h=mk_tag>\cowel_macro</h-><h- data-h=sym_par>(</h->code_point<h- data-h=sym_par>)</h-><h- data-h=sym_brac>{</h->U+<h- data-h=mk_tag>\cowel_char_get_num</h-><h- data-h=sym_brac>{</h-><h- data-h=mk_tag>\cowel_put</h-><h- data-h=sym_brac>}</h-><h- data-h=sym_brac>}</h->
-<h- data-h=mk_tag>\code_point</h-><h- data-h=sym_brac>{</h->x<h- data-h=sym_brac>}</h-></code-block>
+</p><code-block><h- data-h=mk_tag>\cowel_macro</h-><h- data-h=sym_par>(</h->code_point<h- data-h=sym_par>)</h-><h- data-h=sym_brac>{</h->U+<h- data-h=mk_tag>\cowel_char_get_num</h-><h- data-h=sym_par>(</h-><h- data-h=name_attr>...</h-><h- data-h=sym_par>)</h-><h- data-h=sym_brac>}</h->
+<h- data-h=mk_tag>\code_point</h-><h- data-h=sym_par>(</h->x<h- data-h=sym_par>)</h-></code-block>
 </example-block>
 
-<tip-block><p><intro-></intro-> 
-<code><h- data-h=mk_tag>\cowel_char_get_num</h-></code> can also be combined with <code><h- data-h=mk_tag>\cowel_char_by_name</h-></code>
-to produce human-readable descriptions of code points,
-while also keeping our source code readable:
-</p><code-block><h- data-h=mk_tag>\macro</h-><h- data-h=sym_par>(</h->named_char<h- data-h=sym_par>)</h-><h- data-h=sym_brac>{</h->U+<h- data-h=mk_tag>\cowel_char_get_num</h-><h- data-h=sym_par>(</h->4<h- data-h=sym_par>)</h-><h- data-h=sym_brac>{</h-><h- data-h=mk_tag>\N</h-><h- data-h=sym_brac>{</h-><h- data-h=mk_tag>\put</h-><h- data-h=sym_brac>}</h-><h- data-h=sym_brac>}</h-> <h- data-h=mk_tag>\cowel_put</h-><h- data-h=sym_brac>}</h->
-<h- data-h=mk_tag>\named_char</h-><h- data-h=sym_brac>{</h->SECTION SIGN<h- data-h=sym_brac>}</h-></code-block>
-<p>This renders as:
-</p><div class=indent>
-U+00A7 SECTION SIGN
-</div>
-</tip-block>
+<todo-block><p><intro-></intro-> 
+The example above should use a future <code><h- data-h=mk_tag>\cowel_to_upper</h-></code>
+or <code><h- data-h=mk_tag>\cowel_str_to_upper</h-></code> directive
+because conventionally,
+code points are printed out using uppercase hexadecimal digits.
+</p></todo-block>
 
-<p><code><h- data-h=mk_tag>\cowel_char_get_num</h-></code> uses only the first code point within the input text,
-even though the entire input text is processed into plaintext.
-</p>
 <bug-block><p><intro-></intro-> 
-If we provide more than a single code point, some input is discarded:
-</p><code-block><h- data-h=mk_tag>\</h-><h- data-h=mk_tag>cowel_char_get_num</h-><h- data-h=sym_brac>{</h->abc<h- data-h=sym_brac>}</h-></code-block>
+If more than one code point is provided,
+some input is discarded:
+</p><code-block><h- data-h=mk_tag>\</h-><h- data-h=mk_tag>cowel_char_get_num</h-><h- data-h=sym_par>(</h->abc<h- data-h=sym_par>)</h-></code-block>
 <p>This renders as
 </p><div class=indent>
-61
+97
 </div>
-<p>... which corresponds to <code>a</code>, whereas <code>b</code> and <code>c</code> are discarded.
+<p>... which corresponds to '<tt->a</tt->',
+whereas '<tt->b</tt->' and '<tt->c</tt->' are discarded.
 </p></bug-block>
 
 <h3 id=html-utilities><a class=para href=#html-utilities></a>8.3. HTML utilities</h3>

--- a/docs/new_directives.cow
+++ b/docs/new_directives.cow
@@ -240,88 +240,52 @@ they cannot easily tell what the purpose of the character is.
 ){\cowdoc_dir{cowel_char_get_num} \c{mdash} Get digits of character}
 
 \pre{
-\cowel_highlight_as(markup-tag){cowel_char_get_num}(
-  \cowel_highlight_as(markup-attr){zfill}: \cowel_highlight_as(keyword-type){bool} = 0,
-  \cowel_highlight_as(markup-attr){base}: \cowel_highlight_as(keyword-type){int} = 16,
-  \cowel_highlight_as(markup-attr){lower}: \cowel_highlight_as(keyword-type){bool} = false,
-){...}: \cowel_highlight_as(keyword-type){block}
+\cowel_highlight_as(markup-tag){cowel_char_get_num}(\cowel_highlight_as(markup-attr){x}: \cowel_highlight_as(keyword-type){str}): \cowel_highlight_as(keyword-type){int}
 }
 
 The \cowdoc_dir{cowel_char_get_num} directive is essentially the
 inverse of the \cowdoc_dir{cowel_char_by_num} directive.
-Its input is also plaintext content.
-Rather than producing a code point from a digit sequence,
-it produces a digit sequence from its input code point.
-
-This can be fine-tuned with the following parameters:
-\dd{
-  \dt{\cowdoc_attr{zfill}}
-  \dd{
-    The minimum amount of digits that should be produced.
-    This is an integer argument in range [0, 1024], and defaults to zero.
-    If the amount of digits is less than \cowdoc_attr{zfill},
-    it will be left-padded with additional '\tt{0}' characters.
-  }
-
-  \dt{\cowdoc_attr{base}}
-  \dd{
-    The base of the output digit sequence, in range [2, 16].
-    This defaults to 16, meaning that the digits are printed in hexadecimal.
-  }
-
-  \dt{\cowdoc_attr{lower}}
-  \dd{
-    A yes/no plaintext argument, defaulting to \tt{no}.
-    If \tt{yes} is specified, digits beyond '\tt{9}' (i.e. '\tt{A}' to '\tt{F}')
-    will be output in lower case instead.
-}
-}
+It returns the numeric value of the first input code point in \cowdoc_attr{x}.
 
 \Bex{
 COWEL markup:
 \cowblock{\literally{
-U+\cowel_char_get_num(4){x}
+\cowel_char_get_num("x")
+U+\cowel_to_str(cowel_char_get_num("x"), base=16, zpad=4)
 }}
-This renders as:
-\Bindent{
-U+\cowel_char_get_num(4){x}
+Generated HTML:
+\htmlblock{
+\cowel_char_get_num("x")
+U+\cowel_to_str(cowel_char_get_num("x"), base=16, zpad=4)
 }
 Note that U+0078 is the usual way in which Unicode code points are represented.
 That is, \tt{U+}, followed by at least four hexadecimal digits.
 It is also possible to define a macro if we need this frequently:
 \cowblock{\literally{
-\cowel_macro(code_point){U+\cowel_char_get_num{\cowel_put}}
-\code_point{x}
+\cowel_macro(code_point){U+\cowel_char_get_num(...)}
+\code_point(x)
 }}
 }
 
-\Btip{
-\cowdoc_dir{cowel_char_get_num} can also be combined with \cowdoc_dir{cowel_char_by_name}
-to produce human-readable descriptions of code points,
-while also keeping our source code readable:
-\cowblock{\literally{
-\macro(named_char){U+\cowel_char_get_num(4){\N{\put}} \cowel_put}
-\named_char{SECTION SIGN}
-}}
-This renders as:
-\Bindent{
-U+\cowel_char_get_num(4){\N{SECTION SIGN}} SECTION SIGN
+\Btodo{
+The example above should use a future \cowdoc_dir{cowel_to_upper}
+or \cowdoc_dir{cowel_str_to_upper} directive
+because conventionally,
+code points are printed out using uppercase hexadecimal digits.
 }
-}
-
-\cowdoc_dir{cowel_char_get_num} uses only the first code point within the input text,
-even though the entire input text is processed into plaintext.
 
 \Bug{
-If we provide more than a single code point, some input is discarded:
+If more than one code point is provided,
+some input is discarded:
 \cowblock{
-\\cowel_char_get_num{abc}
+\\cowel_char_get_num(abc)
 }
 This renders as
 \Bindent{
-\cowel_char_get_num{a}
+\cowel_char_get_num(a)
 }
-... which corresponds to \cowdoc_c{a}, whereas \cowdoc_c{b} and \cowdoc_c{c} are discarded.
+... which corresponds to '\tt{a}',
+whereas '\tt{b}' and '\tt{c}' are discarded.
 }
 
 \h3{HTML utilities}

--- a/include/cowel/builtin_directive_set.hpp
+++ b/include/cowel/builtin_directive_set.hpp
@@ -142,15 +142,14 @@ Char_By_Name_Behavior final : Code_Point_Behavior {
     get_code_point(const Invocation& call, Context& context) const final;
 };
 
-// TODO: This could return some `integer` value when evaluated rather than being block behavior.
 struct [[nodiscard]]
-Char_Get_Num_Behavior final : Block_Directive_Behavior {
+Char_Get_Num_Behavior final : Int_Directive_Behavior {
     [[nodiscard]]
     constexpr explicit Char_Get_Num_Behavior()
         = default;
 
     [[nodiscard]]
-    Processing_Status splice(Content_Policy& out, const Invocation&, Context&) const final;
+    Result<Integer, Processing_Status> do_evaluate(const Invocation&, Context&) const final;
 };
 
 // clang-format off

--- a/include/cowel/diagnostic.hpp
+++ b/include/cowel/diagnostic.hpp
@@ -150,14 +150,6 @@ inline constexpr std::u8string_view char_nonscalar = u8"char.nonscalar";
 /// @brief In a `\cowel_char` directive,
 /// the input is corrupted UTF-8 text.
 inline constexpr std::u8string_view char_corrupted = u8"char.corrupted";
-/// @brief The `zfill` argument could not be parsed as an integer.
-inline constexpr std::u8string_view char_zfill_not_an_integer = u8"char.zfill.parse";
-/// @brief The `zfill` argument could not be parsed as an integer.
-inline constexpr std::u8string_view char_zfill_range = u8"char.zfill.range";
-/// @brief The `base` argument could not be parsed as an integer.
-inline constexpr std::u8string_view char_base_not_an_integer = u8"char.base.parse";
-/// @brief The `base` argument could not be parsed as an integer.
-inline constexpr std::u8string_view char_base_range = u8"char.base.range";
 /// @brief The `lower` argument is neither `yes` nor `no`.
 inline constexpr std::u8string_view char_lower_invalid = u8"char.lower.invalid";
 

--- a/src/main/cpp/directives/code_point.cpp
+++ b/src/main/cpp/directives/code_point.cpp
@@ -1,4 +1,3 @@
-#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <expected>
@@ -19,8 +18,6 @@
 #include "cowel/util/to_chars.hpp"
 #include "cowel/util/unicode.hpp"
 
-#include "cowel/policy/content_policy.hpp"
-
 #include "cowel/ast.hpp"
 #include "cowel/builtin_directive_set.hpp"
 #include "cowel/content_status.hpp"
@@ -29,7 +26,6 @@
 #include "cowel/directive_processing.hpp"
 #include "cowel/fwd.hpp"
 #include "cowel/invocation.hpp"
-#include "cowel/output_language.hpp"
 
 using namespace std::string_view_literals;
 
@@ -168,65 +164,30 @@ Char_By_Name_Behavior::get_code_point(const Invocation& call, Context& context) 
     );
 }
 
-Processing_Status
-Char_Get_Num_Behavior::splice(Content_Policy& out, const Invocation& call, Context& context) const
+Result<Integer, Processing_Status>
+Char_Get_Num_Behavior::do_evaluate(const Invocation& call, Context& context) const
 {
-    constexpr Integer default_zfill = 0;
-    constexpr Integer min_zfill = 0;
-    constexpr Integer max_zfill = 1024;
-
-    constexpr Integer default_base = 16;
-    constexpr Integer min_base = 2;
-    constexpr Integer max_base = 16;
-
-    Integer_Matcher zfill_integer;
-    Group_Member_Matcher zfill_member { u8"zfill", Optionality::optional, zfill_integer };
-    Integer_Matcher base_integer;
-    Group_Member_Matcher base_member { u8"base", Optionality::optional, base_integer };
-    Boolean_Matcher lower_boolean;
-    Group_Member_Matcher lower_member { u8"lower", Optionality::optional, lower_boolean };
-
-    Group_Member_Matcher* matchers[] { &zfill_member, &base_member, &lower_member };
+    String_Matcher x_matcher { context.get_transient_memory() };
+    Group_Member_Matcher x_member { u8"x", Optionality::mandatory, x_matcher };
+    Group_Member_Matcher* matchers[] { &x_member };
     Pack_Usual_Matcher args_matcher { matchers };
     Group_Pack_Matcher group_matcher { args_matcher };
     Call_Matcher call_matcher { group_matcher };
 
     const auto args_status
         = call_matcher.match_call(call, context, make_fail_callback(), Processing_Status::error);
-
-    const Integer zfill = zfill_integer.get_or_default(default_zfill);
-    if (zfill < min_zfill || zfill > max_zfill) {
-        context.try_error(
-            diagnostic::char_zfill_range, zfill_integer.get_location(),
-            u8"Value for zfill is out of range."sv
-        );
-        return try_generate_error(out, call, context);
+    if (args_status != Processing_Status::ok) {
+        return args_status;
     }
 
-    const Integer base = base_integer.get_or_default(default_base);
-    if (base < min_base || base > max_base) {
-        context.try_error(
-            diagnostic::char_base_range, zfill_integer.get_location(),
-            u8"Value for base is out of range."sv
-        );
-        return try_generate_error(out, call, context);
-    }
-
-    std::pmr::vector<char8_t> input { context.get_transient_memory() };
-    const auto input_status
-        = splice_to_plaintext(input, call.get_content_span(), call.content_frame, context);
-    if (input_status != Processing_Status::ok) {
-        return status_concat(args_status, input_status);
-    }
-
-    const auto input_text = as_u8string_view(input);
+    const std::u8string_view input_text = x_matcher.get();
 
     if (input_text.empty()) {
         context.try_error(
             diagnostic::char_blank, call.directive.get_source_span(),
             u8"Nothing can be generated because the input is empty."sv
         );
-        return try_generate_error(out, call, context);
+        return Processing_Status::error;
     }
 
     const std::expected<utf8::Code_Point_And_Length, utf8::Unicode_Error> decode_result
@@ -236,30 +197,22 @@ Char_Get_Num_Behavior::splice(Content_Policy& out, const Invocation& call, Conte
             diagnostic::char_corrupted, call.directive.get_source_span(),
             u8"The input could not be interpreted as a code point because it is malformed UTF-8."sv
         );
-        return try_generate_error(out, call, context);
+        return Processing_Status::error;
     }
 
     const auto [code_point, length] = *decode_result;
-    if (std::size_t(length) != input.size()) {
-        COWEL_ASSERT(std::size_t(length) <= input.size());
+    if (std::size_t(length) != input_text.size()) {
+        COWEL_ASSERT(std::size_t(length) <= input_text.size());
         context.try_warning(
             diagnostic::ignored_content, call.directive.get_source_span(),
             u8"Some of the code units inside were ignored because only the first given code point "
             u8"is converted. "
-            u8"This can happen if you type a character inside \\Udigits that consist of multiple "
+            u8"This can happen if you type a glyph that consist of multiple "
             u8"code points, like a country flag."sv
         );
     }
 
-    const bool convert_to_upper = !lower_boolean.get_or_default(false);
-    const Characters8 chars
-        = to_characters8(std::uint32_t { code_point }, int(base), convert_to_upper);
-    if (const auto pad_length = std::min(std::size_t(zfill), chars.length())) {
-        out.write(repeated_char_sequence(pad_length, u8'0'), Output_Language::text);
-    }
-    out.write(chars.as_string(), Output_Language::text);
-
-    return status_concat(args_status, input_status);
+    return Integer { code_point };
 }
 
 } // namespace cowel

--- a/test/semantics/big.cow
+++ b/test/semantics/big.cow
@@ -210,8 +210,6 @@ Digit zero: \U{30}.
 
 \u{Underlined} text \u{underlined}.
 
-Digits of digit zero: \Udigits{0}.
-
 \url{https://cowel.org}
 
 \var{Variable} text \var{variable}.


### PR DESCRIPTION
The functionality provided by `zfill` and `base` parameters is now provided by `cowel_to_str(int)` anyway. Working with strings and integers increases composability compared to blocks.