### PR TITLE
Add highlights for parentheses

### DIFF
--- a/editor/vscode/language-configuration.json
+++ b/editor/vscode/language-configuration.json
@@ -4,17 +4,19 @@
     "blockComment": [ "\\*", "*\\" ]
   },
   "brackets": [
+    [ "(", ")" ],
     [ "{", "}" ],
     [ "[", "]" ]
   ],
   "autoClosingPairs": [
+    { "open": "(", "close": ")" },
     { "open": "{", "close": "}" },
     { "open": "[", "close": "]" },
-    { "open": "(", "close": ")", "notIn": ["string", "comment"] },
     { "open": "\"", "close": "\"", "notIn": ["string"] },
     { "open": "\\*", "close": "*\\" }
   ],
   "surroundingPairs": [
+    [ "(", ")" ],
     [ "{", "}" ],
     [ "[", "]" ],
     [ "\"", "\"" ],

--- a/editor/vscode/package.json
+++ b/editor/vscode/package.json
@@ -53,7 +53,13 @@
       {
         "language": "cowel",
         "scopeName": "source.cowel",
-        "path": "./syntaxes/cowel.tmLanguage.json"
+        "path": "./syntaxes/cowel.tmLanguage.json",
+        "balancedBracketScopes": [
+          "*"
+        ],
+        "unbalancedBracketScopes": [
+          "constant.character.escape.bracket.cowel"
+        ]
       }
     ]
   }

--- a/editor/vscode/syntaxes/cowel.tmLanguage.json
+++ b/editor/vscode/syntaxes/cowel.tmLanguage.json
@@ -46,9 +46,14 @@
           "match": "\\\\\\\\"
         },
         {
+          "comment": "Escaped brackets need to be marked with a specific scope so they can be excluded from bracket matching",
+          "name": "constant.character.escape.bracket.cowel",
+          "match": "\\\\[{}\\[\\]()]"
+        },
+        {
           "comment": "Other single-char escapes",
           "name": "constant.character.escape.cowel",
-          "match": "\\\\[{}\\[\\](),.=!\"#$%&'+/;<>?@^|~\\-\\s]"
+          "match": "\\\\[,.=!\"#$%&'+/;<>?@^|~\\-\\s]"
         },
         {
           "name": "constant.character.escape.newline.cowel",


### PR DESCRIPTION
Fixes #154. 
<img width="327" height="85" alt="image" src="https://github.com/user-attachments/assets/0e4d1f55-b00e-487f-a1db-ec4b5efaf4e6" />

Will bump `CHANGELOG.md` if this gets merged.