### PR TITLE
Fix incorrect highlight for directive-splice following `\\` escape sequence

### DIFF
--- a/editor/vscode/syntaxes/cowel.tmLanguage.json
+++ b/editor/vscode/syntaxes/cowel.tmLanguage.json
@@ -24,7 +24,7 @@
     "directives": {
       "patterns": [
         {
-          "begin": "(?<!\\\\)\\\\([a-zA-Z_][a-zA-Z0-9_]*)",
+          "begin": "\\\\([a-zA-Z_][a-zA-Z0-9_]*)",
           "beginCaptures": {
             "0": { "name": "support.function.directive.cowel" }
           },


### PR DESCRIPTION
Fix #153. 

<img width="538" height="61" alt="image" src="https://github.com/user-attachments/assets/294cb8cd-906f-4808-b947-82b1aa76261a" />

This issue happens because the old regex performs negative look-ahead, but the escape pattern already handles that in

```json
{
    "name": "constant.character.escape.backslash.cowel",
    "match": "\\\\\\\\"
},
```

