### PR TITLE
Remove `Type*` from `Value` class

### DIFF
--- a/src/main/cpp/semantics.cpp
+++ b/src/main/cpp/semantics.cpp
@@ -61,21 +61,13 @@ std::u8string Type::get_display_name() const
 Value Value::block(const ast::Primary& block, Frame_Index frame)
 {
     COWEL_ASSERT(block.get_kind() == ast::Primary_Kind::block);
-    return Value {
-        Union { .block = Block_And_Frame { &block, frame } },
-        block_index,
-        &Type::block,
-    };
+    return Value { Union { .block = Block_And_Frame { &block, frame } }, block_index };
 }
 
 Value Value::block(const ast::Directive& block, Frame_Index frame)
 {
     // TODO: assertions
-    return Value {
-        Union { .directive = Directive_And_Frame { &block, frame } },
-        directive_index,
-        &Type::block,
-    };
+    return Value { Union { .directive = Directive_And_Frame { &block, frame } }, directive_index };
 }
 
 } // namespace cowel


### PR DESCRIPTION
The index alone is enough to determined the type, and the size of the Value class could be reduced by eliminating this pointer. Future direction could include reducing the size of `Union::short_string` and using a scoped allocator for `dynamic_string` to avoid the extra polymorphic allocator size.