### PR TITLE
Fix highlight for comment immediately following directive

### DIFF
--- a/editor/vscode/syntaxes/cowel.tmLanguage.json
+++ b/editor/vscode/syntaxes/cowel.tmLanguage.json
@@ -30,6 +30,7 @@
           },
           "end": "(?!\\G)(?!\\(|\\{)",
           "patterns": [
+            { "include": "#comments" },
             { "include": "#directive-arguments" },
             { "include": "#directive-content" }
           ]


### PR DESCRIPTION
Fix #162.

Added `#comments` to one of the directive.end pattern so cases like:
```
\dir\:}
```
and 
```
\ref("\:#paragraph-splitting")
```
have correct highlights. 