### PR TITLE
Fix incorrect highlighting when a directive follows an opening string delimiter

### DIFF
--- a/editor/vscode/syntaxes/cowel.tmLanguage.json
+++ b/editor/vscode/syntaxes/cowel.tmLanguage.json
@@ -28,7 +28,7 @@
           "beginCaptures": {
             "0": { "name": "support.function.directive.cowel" }
           },
-          "end": "(?!\\G)(?!\\(|\\{)",
+          "end": "(?=[^(\\{a-zA-Z0-9_])|(?!\\G)(?!\\(|\\{)",
           "patterns": [
             { "include": "#directive-arguments" },
             { "include": "#directive-content" }


### PR DESCRIPTION
Fix #152. 