### PR TITLE
Change the `show-number` parameter for heading directives to `show_number`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
   - accept a `path: str` parameter instead of a block as input
   - make `cowel_include_text` return `str`
 - change the syntax to be parsed in two phases (#175)
+- change the `show-number` parameter for heading directives to `show_number`
 - add support for typed values in builtin directives (#88)
 - add dedicated `\* ... *\` syntax for block comments (#116)
 - add `\d("x" = y)` syntax for "computed" argument/member names (#179)

--- a/docs/directives/lists-tables-headings.cow
+++ b/docs/directives/lists-tables-headings.cow
@@ -85,10 +85,10 @@ Headings take a \cowdoc_attr{listed} argument, which is a yes/no plaintext argum
 Unless its value is \tt{no}, headings are numbered and added to the table of contents
 (\ref("#dir-make_contents")) automatically.
 
-Headings also take a \cowdoc_attr{show-number} argument, which is a yes/no plaintext argument.
+Headings also take a \cowdoc_attr{show_number} argument, which is a yes/no plaintext argument.
 Unless this is \tt{no},
 the heading number will be included in the title, in the format \tt{1.2.3. Title}.
-However, even if \cowdoc_attr{show-number} is \tt{no},
+However, even if \cowdoc_attr{show_number} is \tt{no},
 the number heading is internally numbered as usual,
 and its number can be seen in the table of contents.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -6292,10 +6292,10 @@ to produce the corresponding HTML tags with the same name.
 Unless its value is <tt->no</tt->, headings are numbered and added to the table of contents
 (<a href=#dir-make_contents>§9.8.1. <code><h- data-h=mk_tag>\make_contents</h-></code> — Make table of contents</a>) automatically.
 </p>
-<p>Headings also take a <tt-><h- data-h=mk_attr>show-number</h-></tt-> argument, which is a yes/no plaintext argument.
+<p>Headings also take a <tt-><h- data-h=mk_attr>show_number</h-></tt-> argument, which is a yes/no plaintext argument.
 Unless this is <tt->no</tt->,
 the heading number will be included in the title, in the format <tt->1.2.3. Title</tt->.
-However, even if <tt-><h- data-h=mk_attr>show-number</h-></tt-> is <tt->no</tt->,
+However, even if <tt-><h- data-h=mk_attr>show_number</h-></tt-> is <tt->no</tt->,
 the number heading is internally numbered as usual,
 and its number can be seen in the table of contents.
 </p>

--- a/include/cowel/diagnostic.hpp
+++ b/include/cowel/diagnostic.hpp
@@ -237,8 +237,8 @@ namespace h {
 
 /// @brief In `\hN` headings, the given `listed` parameter is not `yes` or `no`.
 inline constexpr std::u8string_view listed_invalid = u8"h:listed.invalid";
-/// @brief In `\hN` headings, the given `show-number` parameter is not `yes` or `no`.
-inline constexpr std::u8string_view show_number_invalid = u8"h:show-number.invalid";
+/// @brief In `\hN` headings, the given `show_number` parameter is not `yes` or `no`.
+inline constexpr std::u8string_view show_number_invalid = u8"h:show_number.invalid";
 
 } // namespace h
 

--- a/include/cowel/parameters.hpp
+++ b/include/cowel/parameters.hpp
@@ -11,6 +11,7 @@
 #include "cowel/util/char_sequence.hpp"
 #include "cowel/util/function_ref.hpp"
 #include "cowel/util/source_position.hpp"
+#include "cowel/util/strings.hpp"
 
 #include "cowel/content_status.hpp"
 #include "cowel/context.hpp"
@@ -427,6 +428,7 @@ public:
         , m_optionality { optionality }
         , m_value_matcher { value_matcher }
     {
+        COWEL_DEBUG_ASSERT(is_identifier(name));
     }
 
     [[nodiscard]]

--- a/src/main/cpp/directives/heading.cpp
+++ b/src/main/cpp/directives/heading.cpp
@@ -67,7 +67,7 @@ Heading_Behavior::splice(Content_Policy& out, const Invocation& call, Context& c
     Boolean_Matcher listed_boolean;
     Group_Member_Matcher listed_member { u8"listed"sv, Optionality::optional, listed_boolean };
     Boolean_Matcher show_number_boolean;
-    Group_Member_Matcher show_number_member { u8"show-number"sv, Optionality::optional,
+    Group_Member_Matcher show_number_member { u8"show_number"sv, Optionality::optional,
                                               show_number_boolean };
     Group_Pack_Named_Lazy_Spliceable_Matcher attr_group;
     Group_Member_Matcher attr_member { u8"attr"sv, Optionality::optional, attr_group };


### PR DESCRIPTION
This is necessary because unquoted argument names can no longer contain hyphens, making it inconvenient to provide an argument; it would require quotes.