### PR TITLE
Dismantle `fwd.hpp` for the most part

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,7 @@ set(COMMON_LIBRARY_SOURCES
 
     include/cowel/assets.hpp
     include/cowel/ast.hpp
+    include/cowel/ast_fwd.hpp
     include/cowel/builtin_directive_set.hpp
     include/cowel/call_stack.hpp
     include/cowel/content_status.hpp

--- a/include/cowel/ast.hpp
+++ b/include/cowel/ast.hpp
@@ -13,16 +13,12 @@
 #include "cowel/util/meta.hpp"
 #include "cowel/util/source_position.hpp"
 
+#include "cowel/ast_fwd.hpp"
 #include "cowel/fwd.hpp"
 #include "cowel/memory_resources.hpp"
 #include "cowel/string_kind.hpp"
 
 namespace cowel::ast {
-namespace detail {
-
-using Suppress_Unused_Include_Source_Position_2 = Basic_File_Source_Span<void>;
-
-}
 
 template <typename T>
 using Pmr_Vector = std::vector<T, Propagated_Polymorphic_Allocator<T>>;
@@ -442,13 +438,7 @@ public:
     }
 
     [[nodiscard]]
-    std::span<const ast::Group_Member> get_argument_span() const
-    {
-        if (m_arguments) {
-            return m_arguments->get_members();
-        }
-        return {};
-    }
+    std::span<const ast::Group_Member> get_argument_span() const;
 
     [[nodiscard]]
     Primary* get_content()
@@ -462,13 +452,7 @@ public:
     }
 
     [[nodiscard]]
-    std::span<const ast::Markup_Element> get_content_span() const
-    {
-        if (m_content) {
-            return m_content->get_elements();
-        }
-        return {};
-    }
+    std::span<const ast::Markup_Element> get_content_span() const;
 };
 
 using Member_Value_Variant = std::variant<Directive, Primary>;
@@ -735,6 +719,24 @@ inline std::span<const Group_Member> Primary::get_members() const
 {
     COWEL_DEBUG_ASSERT(m_kind == Primary_Kind::group);
     return std::get<Pmr_Vector<Group_Member>>(m_extra);
+}
+
+[[nodiscard]]
+inline std::span<const ast::Group_Member> Directive::get_argument_span() const
+{
+    if (m_arguments) {
+        return m_arguments->get_members();
+    }
+    return {};
+}
+
+[[nodiscard]]
+inline std::span<const ast::Markup_Element> Directive::get_content_span() const
+{
+    if (m_content) {
+        return m_content->get_elements();
+    }
+    return {};
 }
 // NOLINTEND(readability-redundant-inline-specifier)
 

--- a/include/cowel/ast_fwd.hpp
+++ b/include/cowel/ast_fwd.hpp
@@ -1,0 +1,14 @@
+#ifndef COWEL_AST_FWD_HPP
+#define COWEL_AST_FWD_HPP
+
+namespace cowel::ast {
+
+struct Markup_Element;
+struct Member_Value;
+struct Directive;
+struct Group_Member;
+struct Primary;
+
+} // namespace cowel::ast
+
+#endif

--- a/include/cowel/call_stack.hpp
+++ b/include/cowel/call_stack.hpp
@@ -5,6 +5,7 @@
 #include <memory_resource>
 #include <vector>
 
+#include "cowel/directive_behavior.hpp"
 #include "cowel/fwd.hpp"
 #include "cowel/invocation.hpp"
 
@@ -14,6 +15,8 @@ struct Stack_Frame {
     const Directive_Behavior& behavior;
     const Invocation& invocation;
 };
+
+struct Scoped_Frame;
 
 struct Call_Stack {
 public:

--- a/include/cowel/context.hpp
+++ b/include/cowel/context.hpp
@@ -22,14 +22,6 @@
 
 namespace cowel {
 
-namespace detail {
-
-// We only use the aliases from fwd.hpp, but we need the definition of
-// `Basic_Transparent_String_View_Equals` to actually make this usable.
-using Suppress_Unused_Include_Transparent_Equals = Basic_Transparent_String_View_Equals<void>;
-
-} // namespace detail
-
 struct Name_Resolver {
     [[nodiscard]]
     virtual Distant<std::u8string_view>

--- a/include/cowel/diagnostic.hpp
+++ b/include/cowel/diagnostic.hpp
@@ -11,11 +11,6 @@
 #include "cowel/fwd.hpp"
 
 namespace cowel {
-namespace detail {
-
-using Suppress_Unused_Include_Source_Position = Basic_File_Source_Position<void>;
-
-}
 
 [[nodiscard]]
 constexpr std::strong_ordering operator<=>(Severity x, Severity y) noexcept

--- a/include/cowel/directive_behavior.hpp
+++ b/include/cowel/directive_behavior.hpp
@@ -5,6 +5,7 @@
 
 #include "cowel/content_status.hpp"
 #include "cowel/fwd.hpp"
+#include "cowel/invocation.hpp"
 #include "cowel/type.hpp"
 #include "cowel/value.hpp"
 

--- a/include/cowel/directive_processing.hpp
+++ b/include/cowel/directive_processing.hpp
@@ -10,12 +10,14 @@
 
 #include "cowel/util/assert.hpp"
 #include "cowel/util/html_writer.hpp"
+#include "cowel/util/result.hpp"
 
 #include "cowel/ast.hpp"
 #include "cowel/content_status.hpp"
 #include "cowel/directive_display.hpp"
 #include "cowel/fwd.hpp"
 #include "cowel/invocation.hpp"
+#include "cowel/value.hpp"
 
 namespace cowel {
 

--- a/include/cowel/document_generation.hpp
+++ b/include/cowel/document_generation.hpp
@@ -11,6 +11,7 @@
 #include "cowel/policy/content_policy.hpp"
 
 #include "cowel/content_status.hpp"
+#include "cowel/context.hpp"
 #include "cowel/fwd.hpp"
 #include "cowel/services.hpp"
 

--- a/include/cowel/document_sections.hpp
+++ b/include/cowel/document_sections.hpp
@@ -24,12 +24,6 @@
 
 namespace cowel {
 
-namespace detail {
-
-using Suppress_Unused_Include_Transparent_Less = Basic_Transparent_String_View_Less<void>;
-
-} // namespace detail
-
 struct Section_Content {
 private:
     std::pmr::vector<char8_t> m_data;

--- a/include/cowel/fwd.hpp
+++ b/include/cowel/fwd.hpp
@@ -16,104 +16,22 @@ using Default_Underlying = unsigned char;
 #define COWEL_ENUM_STRING_CASE8(...)                                                               \
     case __VA_ARGS__: return u8## #__VA_ARGS__
 
-struct Annotated_String_Length;
-template <typename>
-struct Annotation_Span;
-enum struct Diagnostic_Highlight : Default_Underlying;
-enum struct Argument_Status : Default_Underlying;
-struct AST_Formatting_Options;
-struct CST_Instruction;
-enum struct CST_Instruction_Kind : Default_Underlying;
-enum struct Attribute_Style : Default_Underlying;
-struct Author_Info;
-struct Builtin_Directive_Set;
-template <typename, typename>
-struct Basic_Annotated_String;
-template <typename File>
-struct Basic_File_Source_Position;
-template <typename File>
-struct Basic_File_Source_Span;
-template <typename>
-struct Basic_Transparent_String_View_Equals;
-template <typename>
-struct Basic_Transparent_String_View_Greater;
-template <typename>
-struct Basic_Transparent_String_View_Hash;
-template <typename>
-struct Basic_Transparent_String_View_Less;
-enum struct Blank_Line_Initial_State : bool;
-enum struct Diagnostic_Highlight : Default_Underlying;
 struct Content_Policy;
 struct Context;
-struct Diagnostic;
-struct Bibliography;
-struct Document_Info;
-struct Document_Sections;
-struct Directive_Behavior;
-struct Error_Tag;
+
 /// @brief The floating-point type corresponding to COWEL's `float` type.
 using Float = double;
-struct Generation_Options;
-enum struct HLJS_Scope : Default_Underlying;
-struct Ignorant_Logger;
-enum struct IO_Error_Code : Default_Underlying;
 /// @brief The type corresponding to COWEL's `int` type.
 /// While the COWEL language has unbounded integers,
 /// this is not implemented yet.
 /// Using 128-bit integers at least provides support beyond 64-bit.
 using Integer = Int128;
-struct Invocation;
-struct Logger;
-struct Name_Resolver;
-struct Null;
-struct Simple_Bibliography;
-struct No_Support_Syntax_Highlighter;
-template <typename, typename>
-struct Result;
-struct Scoped_Frame;
-enum struct Severity : Default_Underlying;
-enum struct Sign_Policy : Default_Underlying;
-struct Source_Position;
-struct Source_Span;
-struct Stack_Frame;
-struct Success_Tag;
-struct Syntax_Highlighter;
-enum struct Syntax_Highlight_Error : Default_Underlying;
-enum struct To_HTML_Mode : Default_Underlying;
-struct Token;
-enum struct Token_Kind : Default_Underlying;
-struct Type;
-enum struct Type_Kind : Default_Underlying;
-struct Unit;
-struct Value;
 
-namespace ast {
-
-struct Markup_Element;
-struct Member_Value;
-struct Directive;
-struct Group_Member;
-struct Primary;
-
-} // namespace ast
-
-template <typename T>
-using Annotated_String = Basic_Annotated_String<char, T>;
-template <typename T>
-using Annotated_String8 = Basic_Annotated_String<char8_t, T>;
-
-using Diagnostic_String = Annotated_String8<Diagnostic_Highlight>;
-
-using HLJS_Annotation_Span = Annotation_Span<HLJS_Scope>;
-
-using Transparent_String_View_Equals = Basic_Transparent_String_View_Equals<char>;
-using Transparent_String_View_Equals8 = Basic_Transparent_String_View_Equals<char8_t>;
-using Transparent_String_View_Greater = Basic_Transparent_String_View_Greater<char>;
-using Transparent_String_View_Greater8 = Basic_Transparent_String_View_Greater<char8_t>;
-using Transparent_String_View_Hash = Basic_Transparent_String_View_Hash<char>;
-using Transparent_String_View_Hash8 = Basic_Transparent_String_View_Hash<char8_t>;
-using Transparent_String_View_Less = Basic_Transparent_String_View_Less<char>;
-using Transparent_String_View_Less8 = Basic_Transparent_String_View_Less<char8_t>;
+enum struct Syntax_Highlight_Error : Default_Underlying {
+    unsupported_language,
+    bad_code,
+    other,
+};
 
 /// @brief A numeric file identifier.
 enum struct File_Id : int { main = -1 }; // NOLINT(performance-enum-size)
@@ -122,9 +40,6 @@ enum struct File_Id : int { main = -1 }; // NOLINT(performance-enum-size)
 /// The special value `root = -1` expresses top-level content,
 /// i.e. content which is not expanded from any macro.
 enum struct Frame_Index : int { root = -1 }; // NOLINT(performance-enum-size)
-
-using File_Source_Position = Basic_File_Source_Position<File_Id>;
-using File_Source_Span = Basic_File_Source_Span<File_Id>;
 
 } // namespace cowel
 

--- a/include/cowel/parameters.hpp
+++ b/include/cowel/parameters.hpp
@@ -18,6 +18,7 @@
 #include "cowel/diagnostic.hpp"
 #include "cowel/fwd.hpp"
 #include "cowel/invocation.hpp"
+#include "cowel/value.hpp"
 
 namespace cowel {
 

--- a/include/cowel/parse.hpp
+++ b/include/cowel/parse.hpp
@@ -8,10 +8,12 @@
 #include <string_view>
 #include <vector>
 
-#include "cowel/ast.hpp"
-#include "cowel/fwd.hpp"
 #include "cowel/util/char_sequence.hpp"
 #include "cowel/util/function_ref.hpp"
+
+#include "cowel/ast.hpp"
+#include "cowel/fwd.hpp"
+#include "cowel/lex.hpp"
 
 namespace cowel {
 

--- a/include/cowel/print.hpp
+++ b/include/cowel/print.hpp
@@ -1,8 +1,7 @@
 #ifndef COWEL_DIAGNOSTICS_HPP
 #define COWEL_DIAGNOSTICS_HPP
 
-#include "cowel/fwd.hpp"
-#include "cowel/util/char_sequence.hpp"
+#include "cowel/settings.hpp"
 
 #ifndef COWEL_EMSCRIPTEN
 #include <iosfwd>
@@ -14,10 +13,21 @@
 #include <string_view>
 #include <vector>
 
+#include "cowel/util/annotated_string.hpp"
 #include "cowel/util/assert.hpp"
+#include "cowel/util/char_sequence.hpp"
 #include "cowel/util/source_position.hpp"
 
+#include "cowel/diagnostic_highlight.hpp"
+
 namespace cowel {
+
+template <typename T>
+using Annotated_String = Basic_Annotated_String<char, T>;
+template <typename T>
+using Annotated_String8 = Basic_Annotated_String<char8_t, T>;
+
+using Diagnostic_String = Annotated_String8<Diagnostic_Highlight>;
 
 /// @brief Returns the line that contains the given index.
 /// @param source the source string
@@ -65,8 +75,6 @@ void print_affected_line(Diagnostic_String& out, std::u8string_view source, cons
 
 void print_assertion_error(Diagnostic_String& out, const Assertion_Error& error);
 
-void print_io_error(Diagnostic_String& out, std::u8string_view file, IO_Error_Code error);
-
 void print_internal_error_notice(Diagnostic_String& out);
 
 void dump_code_string(std::pmr::vector<char8_t>& out, const Diagnostic_String& string, bool colors);
@@ -99,6 +107,7 @@ inline void print_flush_code_string_stderr(const Diagnostic_String& str)
     flush_stderr();
 }
 
+void print_io_error(Diagnostic_String& out, std::u8string_view file, IO_Error_Code error);
 #endif
 
 } // namespace cowel

--- a/include/cowel/services.hpp
+++ b/include/cowel/services.hpp
@@ -8,7 +8,6 @@
 
 #include "ulight/ulight.hpp"
 
-#include "cowel/util/annotation_span.hpp"
 #include "cowel/util/assert.hpp"
 #include "cowel/util/char_sequence.hpp"
 #include "cowel/util/result.hpp"
@@ -19,21 +18,9 @@
 
 namespace cowel {
 
-namespace detail {
-
-using Suppress_Unused_Include_Annotation_Span = Annotation_Span<void>;
-
-} // namespace detail
-
 using Highlight_Span = ulight::Token;
 using ulight::Highlight_Type;
 using Highlight_Lang = ulight::Lang;
-
-enum struct Syntax_Highlight_Error : Default_Underlying {
-    unsupported_language,
-    bad_code,
-    other,
-};
 
 struct Syntax_Highlighter {
 

--- a/include/cowel/util/annotated_string.hpp
+++ b/include/cowel/util/annotated_string.hpp
@@ -11,6 +11,7 @@
 #include "cowel/util/assert.hpp"
 #include "cowel/util/to_chars.hpp"
 
+#include "cowel/diagnostic_highlight.hpp"
 #include "cowel/fwd.hpp"
 
 namespace cowel {

--- a/include/cowel/util/annotation_span.hpp
+++ b/include/cowel/util/annotation_span.hpp
@@ -3,8 +3,6 @@
 
 #include <cstddef>
 
-#include "cowel/fwd.hpp"
-
 namespace cowel {
 
 template <typename T>

--- a/include/cowel/util/source_position.hpp
+++ b/include/cowel/util/source_position.hpp
@@ -205,6 +205,9 @@ struct Basic_File_Source_Position : Source_Position {
         = default;
 };
 
+using File_Source_Position = Basic_File_Source_Position<File_Id>;
+using File_Source_Span = Basic_File_Source_Span<File_Id>;
+
 } // namespace cowel
 
 #endif

--- a/include/cowel/util/transparent_comparison.hpp
+++ b/include/cowel/util/transparent_comparison.hpp
@@ -58,6 +58,15 @@ struct Basic_Transparent_String_View_Less {
     }
 };
 
+using Transparent_String_View_Equals = Basic_Transparent_String_View_Equals<char>;
+using Transparent_String_View_Equals8 = Basic_Transparent_String_View_Equals<char8_t>;
+using Transparent_String_View_Greater = Basic_Transparent_String_View_Greater<char>;
+using Transparent_String_View_Greater8 = Basic_Transparent_String_View_Greater<char8_t>;
+using Transparent_String_View_Hash = Basic_Transparent_String_View_Hash<char>;
+using Transparent_String_View_Hash8 = Basic_Transparent_String_View_Hash<char8_t>;
+using Transparent_String_View_Less = Basic_Transparent_String_View_Less<char>;
+using Transparent_String_View_Less8 = Basic_Transparent_String_View_Less<char8_t>;
+
 } // namespace cowel
 
 #endif

--- a/include/cowel/value.hpp
+++ b/include/cowel/value.hpp
@@ -7,6 +7,7 @@
 #include "cowel/util/fixed_string.hpp"
 #include "cowel/util/strings.hpp"
 
+#include "cowel/ast_fwd.hpp"
 #include "cowel/content_status.hpp"
 #include "cowel/fwd.hpp"
 #include "cowel/gc.hpp"

--- a/src/test/cpp/document_file_testing.cpp
+++ b/src/test/cpp/document_file_testing.cpp
@@ -3,7 +3,6 @@
 #include <string_view>
 #include <vector>
 
-#include "cowel/util/annotated_string.hpp"
 #include "cowel/util/assert.hpp"
 #include "cowel/util/io.hpp"
 #include "cowel/util/result.hpp"
@@ -19,8 +18,6 @@
 
 namespace cowel {
 namespace {
-
-using Suppress_Unused_Include_Annotated_String = Basic_Annotated_String<void, void>;
 
 struct Printing_Diagnostic_Policy : Diagnostic_Policy {
     std::u8string_view file;

--- a/src/test/cpp/test_document_generation.cpp
+++ b/src/test/cpp/test_document_generation.cpp
@@ -42,8 +42,6 @@ namespace {
 
 constexpr std::u8string_view theme_path = u8"ulight/themes/wg21.json";
 
-using Suppress_Unused_Include_Annotated_String = Basic_Annotated_String<void, void>;
-
 [[nodiscard]]
 Processing_Status write_empty_head_document(
     Text_Sink& out,


### PR DESCRIPTION
Having forward declarations of many types causes more problems than it solves. It runs danger of IFNDR due to running SFINAE on incomplete types, and adds maintenance burden. Many of the forward declarations are unnecessary, especially for small enumerations in their own header.

This PR also fixes some potential bugs in ast.hpp caused by forming std::span<T> where T is completed later.