### PR TITLE
Make `diff.hpp` a common utility, add tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -356,6 +356,7 @@ else()
         src/test/cpp/main.cpp
         src/test/cpp/test_char_sequence.cpp
         src/test/cpp/test_chars_strings.cpp
+        src/test/cpp/test_diff.cpp
         src/test/cpp/test_document_generation.cpp
         src/test/cpp/test_draft_uris.cpp
         src/test/cpp/test_html_writer.cpp

--- a/src/test/cpp/diff.hpp
+++ b/src/test/cpp/diff.hpp
@@ -1,111 +1,21 @@
 #ifndef COWEL_TEST_DIFF_HPP
 #define COWEL_TEST_DIFF_HPP
 
-#include <algorithm>
 #include <cstddef>
-#include <memory_resource>
 #include <span>
 #include <string_view>
 #include <vector>
 
 #include "cowel/util/annotated_string.hpp"
-#include "cowel/util/assert.hpp"
+#include "cowel/util/diff.hpp"
 
 #include "cowel/diagnostic_highlight.hpp"
-#include "cowel/fwd.hpp"
 
 namespace cowel {
 
-enum struct Edit_Type : signed char {
-    /// @brief Delete an element in the source sequence.
-    /// Advance by one element in the source sequence.
-    del = -1,
-    /// @brief Keep the element in the source sequence.
-    /// Advance by one element in both sequences.
-    common = 0,
-    /// @brief Insert the element from the target sequence into the source sequence.
-    /// Advance by one element in the target sequence.
-    ins = 1,
-};
-
-/// @brief Uses the
-/// [Needleman-Wunsch algorithm](https://en.wikipedia.org/wiki/Needleman%E2%80%93Wunsch_algorithm)
-/// to compute the Shortest Edit Script to convert sequence `from` into sequence `to`.
-inline std::pmr::vector<Edit_Type> shortest_edit_script(
-    std::span<const std::u8string_view> from,
-    std::span<const std::u8string_view> to,
-    std::pmr::memory_resource* memory
-)
-{
-    std::pmr::vector<std::size_t> f_data((from.size() + 1) * (to.size() + 1), memory);
-    const auto F = [&](std::size_t i, std::size_t j) -> std::size_t& {
-        const std::size_t index = (i * (to.size() + 1)) + j;
-        COWEL_DEBUG_ASSERT(index < f_data.size());
-        return f_data[index];
-    };
-
-    for (std::size_t i = 0; i <= from.size(); ++i) {
-        F(i, 0) = i;
-    }
-    for (std::size_t j = 0; j <= to.size(); ++j) {
-        F(0, j) = j;
-    }
-    for (std::size_t i = 1; i <= from.size(); ++i) {
-        for (std::size_t j = 1; j <= to.size(); ++j) {
-            // The costs here are essentially the same as for Levenshtein distance computation,
-            // except that if the two strings mismatch at a given index,
-            // we consider the cost to be infinite.
-            // This way, the output is made of pure insertions and deletions;
-            // substitutions don't exist.
-            F(i, j) = std::min(
-                {
-                    from[i - 1] == to[j - 1] ? F(i - 1, j - 1) : std::size_t(-1), // common
-                    F(i - 1, j) + 1, // deletion
-                    F(i, j - 1) + 1, // insertion
-                }
-            );
-        }
-    }
-
-    std::size_t i = from.size();
-    std::size_t j = to.size();
-
-    std::pmr::vector<Edit_Type> out { memory };
-    while (i != 0 || j != 0) {
-        if (i != 0 && j != 0 && from[i - 1] == to[j - 1]) {
-            out.push_back(Edit_Type::common);
-            --i;
-            --j;
-        }
-        else if (i != 0 && F(i, j) == F(i - 1, j) + 1) {
-            out.push_back(Edit_Type::del);
-            --i;
-        }
-        else {
-            out.push_back(Edit_Type::ins);
-            --j;
-        }
-    }
-
-    std::ranges::reverse(out);
-    auto it = out.begin();
-    while (it != out.end()) {
-        // Find the next block of insertions/deletions.
-        const auto next_mod_begin = std::ranges::find_if(it, out.end(), [](Edit_Type t) {
-            return t != Edit_Type::common;
-        });
-        const auto next_mod_end = std::ranges::find(next_mod_begin, out.end(), Edit_Type::common);
-        // Partition the block so that deletions all precede insertions.
-        std::ranges::partition(next_mod_begin, next_mod_end, [](Edit_Type t) {
-            return t == Edit_Type::del;
-        });
-        it = next_mod_end;
-    }
-
-    return out;
-}
-
-inline void split_lines(std::pmr::vector<std::u8string_view>& out, std::u8string_view str)
+/// @brief Splits `str` into lines and appends each line to `out`.
+/// Lines are delimited by a single U+000A END OF LINE code unit, i.e. `u8'\n'`.
+inline void split_lines(std::pmr::vector<std::u8string_view>& out, const std::u8string_view str)
 {
     std::size_t pos = 0;
     std::size_t prev = 0;
@@ -117,10 +27,13 @@ inline void split_lines(std::pmr::vector<std::u8string_view>& out, std::u8string
     out.push_back(str.substr(prev));
 }
 
+/// @brief Computes the shortest edit script between the original `from_lines`
+/// necessary to produce `to_lines`,
+/// and appends the script to `out`.
 inline void print_diff(
     Basic_Annotated_String<char8_t, Diagnostic_Highlight>& out,
-    std::span<const std::u8string_view> from_lines,
-    std::span<const std::u8string_view> to_lines
+    const std::span<const std::u8string_view> from_lines,
+    const std::span<const std::u8string_view> to_lines
 )
 {
     const std::pmr::vector<Edit_Type> edits
@@ -160,8 +73,8 @@ inline void print_diff(
 
 inline void print_lines_diff(
     Basic_Annotated_String<char8_t, Diagnostic_Highlight>& out,
-    std::u8string_view from,
-    std::u8string_view to
+    const std::u8string_view from,
+    const std::u8string_view to
 )
 {
     std::pmr::vector<std::u8string_view> from_lines { out.get_memory() };

--- a/src/test/cpp/test_diff.cpp
+++ b/src/test/cpp/test_diff.cpp
@@ -1,0 +1,450 @@
+#include <array>
+#include <string_view>
+
+#include <gtest/gtest.h>
+
+#include "cowel/util/diff.hpp"
+
+namespace cowel {
+namespace {
+
+TEST(Diff, empty)
+{
+    // Note that this test (and all subsequent tests) use std::pmr::vector
+    // for the test expectations (rather than std::array)
+    // because this makes equality comparison possible for EXPECT_EQ.
+    static const std::pmr::vector<Edit_Type> expected;
+
+    const std::pmr::vector<Edit_Type> actual = shortest_edit_script({}, {});
+    EXPECT_EQ(expected, actual);
+}
+
+TEST(Diff, one_line_common)
+{
+    static constexpr std::array<std::u8string_view, 1> from { u8"awoo" };
+    static constexpr auto to = from;
+    static const std::pmr::vector<Edit_Type> expected { Edit_Type::common };
+
+    const std::pmr::vector<Edit_Type> actual = shortest_edit_script(from, to);
+    EXPECT_EQ(expected, actual);
+}
+
+TEST(Diff, one_line_del)
+{
+    static constexpr std::array<std::u8string_view, 1> from { u8"awoo" };
+    static constexpr std::array<std::u8string_view, 0> to;
+    static const std::pmr::vector<Edit_Type> expected { Edit_Type::del };
+
+    const std::pmr::vector<Edit_Type> actual = shortest_edit_script(from, to);
+    EXPECT_EQ(expected, actual);
+}
+
+TEST(Diff, one_line_ins)
+{
+    static constexpr std::array<std::u8string_view, 0> from;
+    static constexpr std::array<std::u8string_view, 1> to { u8"awoo" };
+    static const std::pmr::vector<Edit_Type> expected { Edit_Type::ins };
+
+    const std::pmr::vector<Edit_Type> actual = shortest_edit_script(from, to);
+    EXPECT_EQ(expected, actual);
+}
+
+TEST(Diff, multiple_common_identical)
+{
+    static constexpr std::array<std::u8string_view, 3> from {
+        u8"common",
+        u8"common",
+        u8"common",
+    };
+    static constexpr auto to = from;
+    static const std::pmr::vector<Edit_Type> expected {
+        Edit_Type::common,
+        Edit_Type::common,
+        Edit_Type::common,
+    };
+
+    const std::pmr::vector<Edit_Type> actual = shortest_edit_script(from, to);
+    EXPECT_EQ(expected, actual);
+}
+
+TEST(Diff, multiple_common_distinct)
+{
+    static constexpr std::array<std::u8string_view, 3> from {
+        u8"common1",
+        u8"common2",
+        u8"common3",
+    };
+    static constexpr auto to = from;
+    static const std::pmr::vector<Edit_Type> expected {
+        Edit_Type::common,
+        Edit_Type::common,
+        Edit_Type::common,
+    };
+
+    const std::pmr::vector<Edit_Type> actual = shortest_edit_script(from, to);
+    EXPECT_EQ(expected, actual);
+}
+
+TEST(Diff, multiple_del)
+{
+    static constexpr std::array<std::u8string_view, 3> from {
+        u8"del",
+        u8"del",
+        u8"del",
+    };
+    static constexpr std::array<std::u8string_view, 0> to;
+    static const std::pmr::vector<Edit_Type> expected {
+        Edit_Type::del,
+        Edit_Type::del,
+        Edit_Type::del,
+    };
+
+    const std::pmr::vector<Edit_Type> actual = shortest_edit_script(from, to);
+    EXPECT_EQ(expected, actual);
+}
+
+TEST(Diff, multiple_ins)
+{
+    static constexpr std::array<std::u8string_view, 0> from;
+    static constexpr std::array<std::u8string_view, 3> to {
+        u8"ins",
+        u8"ins",
+        u8"ins",
+    };
+    static const std::pmr::vector<Edit_Type> expected {
+        Edit_Type::ins,
+        Edit_Type::ins,
+        Edit_Type::ins,
+    };
+
+    const std::pmr::vector<Edit_Type> actual = shortest_edit_script(from, to);
+    EXPECT_EQ(expected, actual);
+}
+
+TEST(Diff, common_then_del)
+{
+    static constexpr std::array<std::u8string_view, 3> from {
+        u8"common",
+        u8"del",
+        u8"del",
+    };
+    static constexpr std::array<std::u8string_view, 1> to {
+        u8"common",
+    };
+    static const std::pmr::vector<Edit_Type> expected {
+        Edit_Type::common,
+        Edit_Type::del,
+        Edit_Type::del,
+    };
+
+    const std::pmr::vector<Edit_Type> actual = shortest_edit_script(from, to);
+    EXPECT_EQ(expected, actual);
+}
+
+TEST(Diff, common_then_ins)
+{
+    static constexpr std::array<std::u8string_view, 1> from {
+        u8"common",
+    };
+    static constexpr std::array<std::u8string_view, 3> to {
+        u8"common",
+        u8"ins",
+        u8"ins",
+    };
+    static const std::pmr::vector<Edit_Type> expected {
+        Edit_Type::common,
+        Edit_Type::ins,
+        Edit_Type::ins,
+    };
+
+    const std::pmr::vector<Edit_Type> actual = shortest_edit_script(from, to);
+    EXPECT_EQ(expected, actual);
+}
+
+TEST(Diff, del_then_common)
+{
+    static constexpr std::array<std::u8string_view, 3> from {
+        u8"del",
+        u8"del",
+        u8"common",
+    };
+    static constexpr std::array<std::u8string_view, 1> to {
+        u8"common",
+    };
+    static const std::pmr::vector<Edit_Type> expected {
+        Edit_Type::del,
+        Edit_Type::del,
+        Edit_Type::common,
+    };
+
+    const std::pmr::vector<Edit_Type> actual = shortest_edit_script(from, to);
+    EXPECT_EQ(expected, actual);
+}
+
+TEST(Diff, ins_then_common)
+{
+    static constexpr std::array<std::u8string_view, 1> from {
+        u8"common",
+    };
+    static constexpr std::array<std::u8string_view, 3> to {
+        u8"ins",
+        u8"ins",
+        u8"common",
+    };
+    static const std::pmr::vector<Edit_Type> expected {
+        Edit_Type::ins,
+        Edit_Type::ins,
+        Edit_Type::common,
+    };
+
+    const std::pmr::vector<Edit_Type> actual = shortest_edit_script(from, to);
+    EXPECT_EQ(expected, actual);
+}
+
+TEST(Diff, del_then_ins)
+{
+    // clang-format off
+    static constexpr std::array<std::u8string_view, 2> from {
+        u8"del1",
+        u8"del2",
+    };
+    static constexpr std::array<std::u8string_view, 2> to {
+        u8"ins1",
+        u8"ins2",
+    };
+    static const std::pmr::vector<Edit_Type> expected {
+        Edit_Type::del,
+        Edit_Type::del,
+        Edit_Type::ins,
+        Edit_Type::ins,
+    };
+    // clang-format on
+
+    const std::pmr::vector<Edit_Type> actual = shortest_edit_script(from, to);
+    EXPECT_EQ(expected, actual);
+}
+
+TEST(Diff, mixed_operations)
+{
+    // clang-format off
+    static constexpr std::array<std::u8string_view, 4> from {
+        u8"common1",
+        u8"del1",
+        u8"common2",
+        u8"del2",
+    };
+    static constexpr std::array<std::u8string_view, 4> to {
+        u8"common1",
+        u8"ins1",
+        u8"common2",
+        u8"ins2",
+    };
+    static const std::pmr::vector<Edit_Type> expected {
+        Edit_Type::common,
+        Edit_Type::del,
+        Edit_Type::ins,
+        Edit_Type::common,
+        Edit_Type::del,
+        Edit_Type::ins,
+    };
+    // clang-format on
+
+    const std::pmr::vector<Edit_Type> actual = shortest_edit_script(from, to);
+    EXPECT_EQ(expected, actual);
+}
+
+TEST(Diff, interleaved_changes)
+{
+    // clang-format off
+    static constexpr std::array<std::u8string_view, 5> from {
+        u8"common1",
+        u8"del",
+        u8"common2",
+        u8"del",
+        u8"common3",
+    };
+    static constexpr std::array<std::u8string_view, 5> to {
+        u8"common1",
+        u8"ins1",
+        u8"common2",
+        u8"ins2",
+        u8"common3",
+    };
+    static const std::pmr::vector<Edit_Type> expected {
+        Edit_Type::common,
+        Edit_Type::del, 
+        Edit_Type::ins, 
+        Edit_Type::common,
+        Edit_Type::del, 
+        Edit_Type::ins, 
+        Edit_Type::common,
+    };
+    // clang-format on
+
+    const std::pmr::vector<Edit_Type> actual = shortest_edit_script(from, to);
+    EXPECT_EQ(expected, actual);
+}
+
+TEST(Diff, all_different)
+{
+    // clang-format off
+    static constexpr std::array<std::u8string_view, 3> from {
+        u8"del1",
+        u8"del2",
+        u8"del3",
+    };
+    static constexpr std::array<std::u8string_view, 3> to {
+        u8"ins1",
+        u8"ins2",
+        u8"ins3",
+    };
+    static const std::pmr::vector<Edit_Type> expected {
+        Edit_Type::del,
+        Edit_Type::del,
+        Edit_Type::del,
+        Edit_Type::ins,
+        Edit_Type::ins,
+        Edit_Type::ins,
+    };
+    // clang-format on
+
+    const std::pmr::vector<Edit_Type> actual = shortest_edit_script(from, to);
+    EXPECT_EQ(expected, actual);
+}
+
+TEST(Diff, del_ins_partition_test)
+{
+    // clang-format off
+    static constexpr std::array<std::u8string_view, 4> from {
+        u8"common1",
+        u8"del1",
+        u8"del2",
+        u8"common2",
+    };
+    static constexpr std::array<std::u8string_view, 4> to {
+        u8"common1",
+        u8"ins1",
+        u8"ins2",
+        u8"common2",
+    };
+    static const std::pmr::vector<Edit_Type> expected {
+        Edit_Type::common,
+        Edit_Type::del,
+        Edit_Type::del,
+        Edit_Type::ins,
+        Edit_Type::ins,
+        Edit_Type::common,
+    };
+    // clang-format on
+
+    const std::pmr::vector<Edit_Type> actual = shortest_edit_script(from, to);
+    EXPECT_EQ(expected, actual);
+}
+
+TEST(Diff, prefix_match)
+{
+    static constexpr std::array<std::u8string_view, 3> from {
+        u8"common1",
+        u8"common2",
+        u8"del",
+    };
+    static constexpr std::array<std::u8string_view, 2> to {
+        u8"common1",
+        u8"common2",
+    };
+    static const std::pmr::vector<Edit_Type> expected {
+        Edit_Type::common,
+        Edit_Type::common,
+        Edit_Type::del,
+    };
+
+    const std::pmr::vector<Edit_Type> actual = shortest_edit_script(from, to);
+    EXPECT_EQ(expected, actual);
+}
+
+TEST(Diff, suffix_match)
+{
+    static constexpr std::array<std::u8string_view, 3> from {
+        u8"del",
+        u8"common1",
+        u8"common2",
+    };
+    static constexpr std::array<std::u8string_view, 2> to {
+        u8"common1",
+        u8"common2",
+    };
+    static const std::pmr::vector<Edit_Type> expected {
+        Edit_Type::del,
+        Edit_Type::common,
+        Edit_Type::common,
+    };
+
+    const std::pmr::vector<Edit_Type> actual = shortest_edit_script(from, to);
+    EXPECT_EQ(expected, actual);
+}
+
+TEST(Diff, middle_match)
+{
+    static constexpr std::array<std::u8string_view, 3> from {
+        u8"del",
+        u8"common",
+        u8"del",
+    };
+    static constexpr std::array<std::u8string_view, 1> to {
+        u8"common",
+    };
+    static const std::pmr::vector<Edit_Type> expected {
+        Edit_Type::del,
+        Edit_Type::common,
+        Edit_Type::del,
+    };
+
+    const std::pmr::vector<Edit_Type> actual = shortest_edit_script(from, to);
+    EXPECT_EQ(expected, actual);
+}
+
+TEST(Diff, complex_scenario)
+{
+    // clang-format off
+    static constexpr std::array<std::u8string_view, 8> from {
+        u8"header",
+        u8"function1",
+        u8"function2",
+        u8"function3",
+        u8"middle",
+        u8"oldcode1",
+        u8"oldcode2",
+        u8"footer",
+    };
+    static constexpr std::array<std::u8string_view, 8> to {
+        u8"header",
+        u8"function1",
+        u8"function4",
+        u8"function5",
+        u8"middle",
+        u8"newcode1",
+        u8"newcode2",
+        u8"footer",
+    };
+    static const std::pmr::vector<Edit_Type> expected {
+        Edit_Type::common, // header
+        Edit_Type::common, // function1
+        Edit_Type::del, // function2
+        Edit_Type::del, // function3
+        Edit_Type::ins, // function4
+        Edit_Type::ins, // function5
+        Edit_Type::common, // middle
+        Edit_Type::del, // oldcode1
+        Edit_Type::del, // oldcode2
+        Edit_Type::ins, // newcode1
+        Edit_Type::ins, // newcode2
+        Edit_Type::common, // footer
+    };
+    // clang-format on
+
+    const std::pmr::vector<Edit_Type> actual = shortest_edit_script(from, to);
+    EXPECT_EQ(expected, actual);
+}
+
+} // namespace
+} // namespace cowel


### PR DESCRIPTION
The shortest_edit_script function is currently entirely untested, which is problematic. If the node build is to run file tests, it could use it could use a diff utility if the expected and actual HTML differ.