### PR TITLE
Fix directive-splices accepting multiple argument lists

### DIFF
--- a/editor/vscode/syntaxes/cowel.tmLanguage.json
+++ b/editor/vscode/syntaxes/cowel.tmLanguage.json
@@ -68,21 +68,6 @@
             { "include": "#argument" },
             { "include": "#comments" }
           ]
-        },
-        {
-          "name": "meta.arguments.cowel",
-          "begin": "(?<=\\))\\(",
-          "beginCaptures": {
-            "0": { "name": "punctuation.section.arguments.begin.cowel" }
-          },
-          "end": "\\)",
-          "endCaptures": {
-            "0": { "name": "punctuation.section.arguments.end.cowel" }
-          },
-          "patterns": [
-            { "include": "#argument" },
-            { "include": "#comments" }
-          ]
         }
       ]
     },

--- a/editor/vscode/tests/fixtures/single_arg_list.cowel
+++ b/editor/vscode/tests/fixtures/single_arg_list.cowel
@@ -1,0 +1,2 @@
+\test(arg1)(arg2)
+

--- a/editor/vscode/tests/fixtures/single_arg_list.cowel.json
+++ b/editor/vscode/tests/fixtures/single_arg_list.cowel.json
@@ -1,0 +1,33 @@
+{
+  "description": "Directives should only take one argument list",
+  "assertions": [
+    {
+      "type": "scope-at",
+      "line": 0,
+      "col": 0,
+      "expectedScopes": ["source.cowel", "support.function.directive.cowel"],
+      "description": "Directive name has correct scope"
+    },
+    {
+      "type": "scope-at",
+      "line": 0,
+      "col": 5,
+      "expectedScopes": ["source.cowel", "meta.arguments.cowel", "punctuation.section.arguments.begin.cowel"],
+      "description": "First argument list start"
+    },
+    {
+      "type": "scope-at",
+      "line": 0,
+      "col": 10,
+      "expectedScopes": ["source.cowel", "meta.arguments.cowel", "punctuation.section.arguments.end.cowel"],
+      "description": "First argument list end"
+    },
+    {
+      "type": "scope-at",
+      "line": 0,
+      "col": 11,
+      "expectedScopes": ["source.cowel"],
+      "description": "Second argument list start (should be plain text)"
+    }
+  ]
+}


### PR DESCRIPTION
Fix #215. Note that #218 is still present so the highlighting may be wrong in some cases.