### PR TITLE
Fix unquoted-string not highlighting like string

### DIFF
--- a/editor/vscode/syntaxes/cowel.tmLanguage.json
+++ b/editor/vscode/syntaxes/cowel.tmLanguage.json
@@ -120,6 +120,10 @@
         { "include": "#literals" },
         { "include": "#strings" },
         {
+          "name": "string.unquoted.cowel",
+          "match": "[a-zA-Z_][a-zA-Z0-9_-]*"
+        },
+        {
           "comment": "Nested groups",
           "begin": "\\(",
           "beginCaptures": {

--- a/editor/vscode/tests/fixtures/unquoted_string.cowel
+++ b/editor/vscode/tests/fixtures/unquoted_string.cowel
@@ -1,0 +1,2 @@
+\test(arg1)
+\test(valid_identifier)

--- a/editor/vscode/tests/fixtures/unquoted_string.cowel.json
+++ b/editor/vscode/tests/fixtures/unquoted_string.cowel.json
@@ -1,0 +1,19 @@
+{
+  "description": "Unquoted strings (identifiers) should be highlighted as strings",
+  "assertions": [
+    {
+      "type": "scope-at",
+      "line": 0,
+      "col": 6,
+      "expectedScopes": ["source.cowel", "meta.arguments.cowel", "string.unquoted.cowel"],
+      "description": "arg1 is highlighted as unquoted string"
+    },
+    {
+      "type": "scope-at",
+      "line": 1,
+      "col": 6,
+      "expectedScopes": ["source.cowel", "meta.arguments.cowel", "string.unquoted.cowel"],
+      "description": "valid_identifier is highlighted as unquoted string"
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #218.

<img width="280" height="69" alt="image" src="https://github.com/user-attachments/assets/ee2c31b8-c9ec-40c5-b25c-29f296b7c39f" />
