### PR TITLE
Add `cowel_str_find` directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## **Next version** (???)
 
+- change `null` from erroring when spliced to producing the string `"null"`
 - add the following string and regular expression directives (#183, #221):
   - `cowel_str_contains`
+  - `cowel_str_find`
   - `cowel_str_match`
   - `cowel_str_replace_first`
   - `cowel_str_replace_all`

--- a/docs/index.html
+++ b/docs/index.html
@@ -1738,16 +1738,18 @@ h1 {
 <div class=toc-num data-level=4>8.14.3</div>
 <a href=#dir-cowel_str_contains><h4><code><h- data-h=mk_tag>\cowel_str_contains</h-></code> — Test if a string contains another string</h4></a>
 <div class=toc-num data-level=4>8.14.4</div>
-<a href=#dir-cowel_str_match><h4><code><h- data-h=mk_tag>\cowel_str_match</h-></code> — Test if a string matches a regular expression</h4></a>
+<a href=#dir-cowel_str_find><h4><code><h- data-h=mk_tag>\cowel_str_find</h-></code> — Find the position of a string</h4></a>
 <div class=toc-num data-level=4>8.14.5</div>
-<a href=#dir-cowel_str_to_lower><h4><code><h- data-h=mk_tag>\cowel_str_to_lower</h-></code> — Convert string to lowercase</h4></a>
+<a href=#dir-cowel_str_match><h4><code><h- data-h=mk_tag>\cowel_str_match</h-></code> — Test if a string matches a regular expression</h4></a>
 <div class=toc-num data-level=4>8.14.6</div>
-<a href=#dir-cowel_str_to_upper><h4><code><h- data-h=mk_tag>\cowel_str_to_upper</h-></code> — Convert string to uppercase</h4></a>
+<a href=#dir-cowel_str_to_lower><h4><code><h- data-h=mk_tag>\cowel_str_to_lower</h-></code> — Convert string to lowercase</h4></a>
 <div class=toc-num data-level=4>8.14.7</div>
-<a href=#dir-cowel_str_replace_first><h4><code><h- data-h=mk_tag>\cowel_str_replace_first</h-></code> — Replace first occurrence</h4></a>
+<a href=#dir-cowel_str_to_upper><h4><code><h- data-h=mk_tag>\cowel_str_to_upper</h-></code> — Convert string to uppercase</h4></a>
 <div class=toc-num data-level=4>8.14.8</div>
-<a href=#dir-cowel_str_replace_all><h4><code><h- data-h=mk_tag>\cowel_str_replace_all</h-></code> — Replace every occurrence</h4></a>
+<a href=#dir-cowel_str_replace_first><h4><code><h- data-h=mk_tag>\cowel_str_replace_first</h-></code> — Replace first occurrence</h4></a>
 <div class=toc-num data-level=4>8.14.9</div>
+<a href=#dir-cowel_str_replace_all><h4><code><h- data-h=mk_tag>\cowel_str_replace_all</h-></code> — Replace every occurrence</h4></a>
+<div class=toc-num data-level=4>8.14.10</div>
 <a href=#dir-cowel_regex><h4><code><h- data-h=mk_tag>\cowel_regex</h-></code> — Create a regular expression</h4></a>
 <div class=toc-num data-level=3>8.15</div>
 <a href=#variable-management><h3>Variable management</h3></a>
@@ -5624,7 +5626,41 @@ true
 true</code-block>
 </example-block>
 
-<h4 id=dir-cowel_str_match><a class=para href=#dir-cowel_str_match></a>8.14.4. <code><h- data-h=mk_tag>\cowel_str_match</h-></code> — Test if a string matches a regular expression</h4>
+<h4 id=dir-cowel_str_find><a class=para href=#dir-cowel_str_find></a>8.14.4. <code><h- data-h=mk_tag>\cowel_str_find</h-></code> — Find the position of a string</h4>
+
+<pre>
+<h- data-h=mk_tag>cowel_str_find</h->(<h- data-h=mk_attr>text</h->: <h- data-h=kw_type>str</h->, <h- data-h=mk_attr>needle</h->: <h- data-h=kw_type>str | regex</h->): <h- data-h=kw_type>int | null</h->
+</pre>
+
+<p>Returns the code point index
+of the first occurrence of <tt-><h- data-h=mk_attr>needle</h-></tt-> within <tt-><h- data-h=mk_attr>text</h-></tt->,
+or <code>null</code> if there is none.
+Always returns <code>0</code> if <tt-><h- data-h=mk_attr>needle</h-></tt->
+is an empty string or empty regular expression.
+</p>
+<example-block><p><intro-></intro-> 
+COWEL markup:
+</p><code-block><h- data-h=cmt_dlim>\:</h-><h- data-h=cmt> "o" character is found in "awoo"</h->
+o: <h- data-h=mk_tag>\cowel_str_find</h-><h- data-h=sym_par>(</h-><h- data-h=str_dlim>"</h-><h- data-h=str>awoo</h-><h- data-h=str_dlim>"</h-><h- data-h=sym_punc>,</h-> <h- data-h=str_dlim>"</h-><h- data-h=str>o</h-><h- data-h=str_dlim>"</h-><h- data-h=sym_par>)</h->
+<h- data-h=cmt_dlim>\:</h-><h- data-h=cmt> "A" character is not found.</h->
+A: <h- data-h=mk_tag>\cowel_str_find</h-><h- data-h=sym_par>(</h-><h- data-h=str_dlim>"</h-><h- data-h=str>awoo</h-><h- data-h=str_dlim>"</h-><h- data-h=sym_punc>,</h-> <h- data-h=str_dlim>"</h-><h- data-h=str>A</h-><h- data-h=str_dlim>"</h-><h- data-h=sym_par>)</h->
+<h- data-h=cmt_dlim>\:</h-><h- data-h=cmt> Sequence of one or more "o" characters is found.</h->
+o+: <h- data-h=mk_tag>\cowel_str_find</h-><h- data-h=sym_par>(</h-><h- data-h=str_dlim>"</h-><h- data-h=str>awoo</h-><h- data-h=str_dlim>"</h-><h- data-h=sym_punc>,</h-> <h- data-h=mk_tag>cowel_regex</h-><h- data-h=sym_par>(</h-><h- data-h=str_dlim>"</h-><h- data-h=str>o+</h-><h- data-h=str_dlim>"</h-><h- data-h=sym_par>)</h-><h- data-h=sym_par>)</h->
+
+<h- data-h=cmt_dlim>\:</h-><h- data-h=cmt> Empty string is always found.</h->
+<h- data-h=mk_tag>\cowel_str_find</h-><h- data-h=sym_par>(</h-><h- data-h=str_dlim>"</h-><h- data-h=str>awoo</h-><h- data-h=str_dlim>"</h-><h- data-h=sym_punc>,</h-> <h- data-h=str_dlim>"</h-><h- data-h=str_dlim>"</h-><h- data-h=sym_par>)</h->
+<h- data-h=cmt_dlim>\:</h-><h- data-h=cmt> Empty regular expression is always found.</h->
+<h- data-h=mk_tag>\cowel_str_find</h-><h- data-h=sym_par>(</h-><h- data-h=str_dlim>"</h-><h- data-h=str>awoo</h-><h- data-h=str_dlim>"</h-><h- data-h=sym_punc>,</h-> <h- data-h=mk_tag>cowel_regex</h-><h- data-h=sym_par>(</h-><h- data-h=str_dlim>"</h-><h- data-h=str_dlim>"</h-><h- data-h=sym_par>)</h-><h- data-h=sym_par>)</h-></code-block>
+<p>Generated HTML:
+</p><code-block>o: 2
+A: null
+o+: 2
+
+0
+0</code-block>
+</example-block>
+
+<h4 id=dir-cowel_str_match><a class=para href=#dir-cowel_str_match></a>8.14.5. <code><h- data-h=mk_tag>\cowel_str_match</h-></code> — Test if a string matches a regular expression</h4>
 
 <pre>
 <h- data-h=mk_tag>cowel_str_match</h->(<h- data-h=mk_attr>text</h->: <h- data-h=kw_type>str</h->, <h- data-h=mk_attr>regex</h->: <h- data-h=kw_type>regex</h->): <h- data-h=kw_type>bool</h->
@@ -5642,7 +5678,7 @@ COWEL markup:
 false</code-block>
 </example-block>
 
-<h4 id=dir-cowel_str_to_lower><a class=para href=#dir-cowel_str_to_lower></a>8.14.5. <code><h- data-h=mk_tag>\cowel_str_to_lower</h-></code> — Convert string to lowercase</h4>
+<h4 id=dir-cowel_str_to_lower><a class=para href=#dir-cowel_str_to_lower></a>8.14.6. <code><h- data-h=mk_tag>\cowel_str_to_lower</h-></code> — Convert string to lowercase</h4>
 
 <pre>
 <h- data-h=mk_tag>cowel_str_to_lower</h->(<h- data-h=mk_attr>x</h->: <h- data-h=kw_type>str</h->): <h- data-h=kw_type>str</h->
@@ -5661,7 +5697,7 @@ COWEL markup:
 </p><code-block>awoo äöü 123</code-block>
 </example-block>
 
-<h4 id=dir-cowel_str_to_upper><a class=para href=#dir-cowel_str_to_upper></a>8.14.6. <code><h- data-h=mk_tag>\cowel_str_to_upper</h-></code> — Convert string to uppercase</h4>
+<h4 id=dir-cowel_str_to_upper><a class=para href=#dir-cowel_str_to_upper></a>8.14.7. <code><h- data-h=mk_tag>\cowel_str_to_upper</h-></code> — Convert string to uppercase</h4>
 
 <pre>
 <h- data-h=mk_tag>cowel_str_to_upper</h->(<h- data-h=mk_attr>x</h->: <h- data-h=kw_type>str</h->): <h- data-h=kw_type>str</h->
@@ -5680,7 +5716,7 @@ COWEL markup:
 </p><code-block>AWOO ÄÖÜ STRASSE 123</code-block>
 </example-block>
 
-<h4 id=dir-cowel_str_replace_first><a class=para href=#dir-cowel_str_replace_first></a>8.14.7. <code><h- data-h=mk_tag>\cowel_str_replace_first</h-></code> — Replace first occurrence</h4>
+<h4 id=dir-cowel_str_replace_first><a class=para href=#dir-cowel_str_replace_first></a>8.14.8. <code><h- data-h=mk_tag>\cowel_str_replace_first</h-></code> — Replace first occurrence</h4>
 
 <pre>
 <h- data-h=mk_tag>cowel_str_replace_first</h->(
@@ -5714,7 +5750,7 @@ Replace everything: xyz
 No replacement:     awoo</code-block>
 </example-block>
 
-<h4 id=dir-cowel_str_replace_all><a class=para href=#dir-cowel_str_replace_all></a>8.14.8. <code><h- data-h=mk_tag>\cowel_str_replace_all</h-></code> — Replace every occurrence</h4>
+<h4 id=dir-cowel_str_replace_all><a class=para href=#dir-cowel_str_replace_all></a>8.14.9. <code><h- data-h=mk_tag>\cowel_str_replace_all</h-></code> — Replace every occurrence</h4>
 
 <pre>
 <h- data-h=mk_tag>cowel_str_replace_all</h->(
@@ -5753,7 +5789,7 @@ Replace everything: xyz
 No replacement:     awoo</code-block>
 </example-block>
 
-<h4 id=dir-cowel_regex><a class=para href=#dir-cowel_regex></a>8.14.9. <code><h- data-h=mk_tag>\cowel_regex</h-></code> — Create a regular expression</h4>
+<h4 id=dir-cowel_regex><a class=para href=#dir-cowel_regex></a>8.14.10. <code><h- data-h=mk_tag>\cowel_regex</h-></code> — Create a regular expression</h4>
 
 <pre>
 <h- data-h=mk_tag>cowel_regex</h->(<h- data-h=mk_attr>pattern</h->: <h- data-h=kw_type>str</h->, <h- data-h=mk_attr>flags</h->: <h- data-h=kw_type>str</h-> = ""): <h- data-h=kw_type>regex</h->

--- a/docs/new_directives.cow
+++ b/docs/new_directives.cow
@@ -2316,6 +2316,46 @@ true
 }
 
 \h4(
+  id = "dir-cowel_str_find"
+){\cowdoc_dir{cowel_str_find} \c{mdash} Find the position of a string}
+
+\pre{
+\cowel_highlight_as("markup-tag"){cowel_str_find}(\cowdoc_param("text", "str"), \cowdoc_param("needle", "str | regex")): \cowel_highlight_as("keyword-type"){int | null}
+}
+
+Returns the code point index
+of the first occurrence of \cowdoc_attr{needle} within \cowdoc_attr{text},
+or \cowdoc_c{null} if there is none.
+Always returns \cowdoc_c{0} if \cowdoc_attr{needle}
+is an empty string or empty regular expression.
+
+\Bex{
+COWEL markup:
+\cowblock{\literally{
+\: "o" character is found in "awoo"
+o: \cowel_str_find("awoo", "o")
+\: "A" character is not found.
+A: \cowel_str_find("awoo", "A")
+\: Sequence of one or more "o" characters is found.
+o+: \cowel_str_find("awoo", cowel_regex("o+"))
+
+\: Empty string is always found.
+\cowel_str_find("awoo", "")
+\: Empty regular expression is always found.
+\cowel_str_find("awoo", cowel_regex(""))
+}}
+Generated HTML:
+\htmlblock{
+o: 2
+A: null
+o+: 2
+
+0
+0
+}
+}
+
+\h4(
   id = "dir-cowel_str_match"
 ){\cowdoc_dir{cowel_str_match} \c{mdash} Test if a string matches a regular expression}
 

--- a/include/cowel/builtin_directive_set.hpp
+++ b/include/cowel/builtin_directive_set.hpp
@@ -239,6 +239,24 @@ Str_Contains_Behavior final : Bool_Directive_Behavior {
     Result<bool, Processing_Status> do_evaluate(const Invocation&, Context&) const override;
 };
 
+struct [[nodiscard]]
+Str_Find_Behavior final : Directive_Behavior {
+private:
+    static constexpr Type alternatives[] { Type::null, Type::integer };
+    static constexpr Type return_type = Type::union_of(alternatives);
+    static_assert(return_type.is_canonical());
+
+public:
+    [[nodiscard]]
+    constexpr explicit Str_Find_Behavior()
+        : Directive_Behavior { return_type }
+    {
+    }
+
+    [[nodiscard]]
+    Result<Value, Processing_Status> evaluate(const Invocation&, Context&) const override;
+};
+
 enum struct Str_Replacement_Kind : bool {
     first,
     all,

--- a/include/cowel/value.hpp
+++ b/include/cowel/value.hpp
@@ -142,6 +142,8 @@ public:
     [[nodiscard]]
     static constexpr Value boolean(bool value) noexcept;
     [[nodiscard]]
+    static constexpr Value integer(Int128 value) noexcept;
+    [[nodiscard]]
     static constexpr Value integer(const Big_Int& value) noexcept;
     [[nodiscard]]
     static constexpr Value integer(Big_Int&& value) noexcept;
@@ -660,6 +662,10 @@ constexpr Value& Value::operator=(Value&& other) noexcept
 constexpr Value Value::boolean(const bool value) noexcept
 {
     return Value { Union { .boolean = value }, boolean_index };
+}
+constexpr Value Value::integer(const Int128 value) noexcept
+{
+    return Value { Union { .integer = Big_Int { value } }, integer_index };
 }
 constexpr Value Value::integer(const Big_Int& value) noexcept
 {

--- a/src/main/cpp/builtin_directive_set.cpp
+++ b/src/main/cpp/builtin_directive_set.cpp
@@ -139,6 +139,8 @@ constexpr Unary_Numeric_Expression_Behavior cowel_sqrt //
     { Unary_Numeric_Expression_Kind::sqrt };
 constexpr Str_Contains_Behavior cowel_str_contains //
     {};
+constexpr Str_Find_Behavior cowel_str_find //
+    {};
 constexpr Str_Length_Behavior cowel_str_length //
     { Str_Length_Kind::code_point };
 constexpr Str_Match_Behavior cowel_str_match //
@@ -468,6 +470,7 @@ constexpr Name_And_Behavior behaviors_by_name[] {
     COWEL_NAME_AND_BEHAVIOR_ENTRY(cowel_source_as_text),
     COWEL_NAME_AND_BEHAVIOR_ENTRY(cowel_sqrt),
     COWEL_NAME_AND_BEHAVIOR_ENTRY(cowel_str_contains),
+    COWEL_NAME_AND_BEHAVIOR_ENTRY(cowel_str_find),
     COWEL_NAME_AND_BEHAVIOR_ENTRY(cowel_str_length),
     COWEL_NAME_AND_BEHAVIOR_ENTRY(cowel_str_match),
     COWEL_NAME_AND_BEHAVIOR_ENTRY(cowel_str_replace_all),

--- a/src/main/cpp/directive_processing.cpp
+++ b/src/main/cpp/directive_processing.cpp
@@ -162,7 +162,8 @@ const Type& get_static_type(const ast::Directive& directive, Context& context)
 const Type& get_type(const ast::Primary& primary)
 {
     // FIXME: This isn't actually the correct type.
-    static const Type group_anything = Type::group_of({ Type::pack_of(auto(Type::any)) });
+    static constexpr auto pack_any = Type::pack_of(&Type::any);
+    static const Type group_anything = Type::group_of({ &pack_any, 1 });
 
     switch (primary.get_kind()) {
     case ast::Primary_Kind::unit_literal: return Type::unit;
@@ -393,7 +394,6 @@ Processing_Status splice_value(
     case Type_Kind::lazy: {
         COWEL_ASSERT_UNREACHABLE(u8"Values of this type should not exist.");
     }
-    case Type_Kind::null:
     case Type_Kind::regex:
     case Type_Kind::group: {
         context.try_error(
@@ -407,6 +407,11 @@ Processing_Status splice_value(
             )
         );
         return Processing_Status::error;
+    }
+
+    case Type_Kind::null: {
+        out.write(u8"null"sv, Output_Language::text);
+        return Processing_Status::ok;
     }
 
     case Type_Kind::unit: {

--- a/src/main/cpp/directives/macros.cpp
+++ b/src/main/cpp/directives/macros.cpp
@@ -220,7 +220,10 @@ Put_Behavior::resolve(const Invocation& call, Context& context) const
         return Processing_Status::error;
     }
 
-    static const auto else_type = Type::canonical_union_of({ Type::block, Type::str });
+    static constexpr Type else_alternatives[] { Type::str, Type::block };
+    static constexpr auto else_type = Type::union_of(else_alternatives);
+    static_assert(else_type.is_canonical());
+
     Lazy_Value_Of_Type_Matcher else_matcher { &else_type };
     Group_Member_Matcher else_member { u8"else"sv, Optionality::optional, else_matcher };
     Group_Member_Matcher* const parameters[] { &else_member };

--- a/test/semantics/str/find_regex.cow
+++ b/test/semantics/str/find_regex.cow
@@ -1,0 +1,27 @@
+\test_input{
+\cowel_str_find("", cowel_regex(""))
+\cowel_str_find("awoo", cowel_regex(""))
+
+\cowel_str_find("awoo", cowel_regex("a"))
+\cowel_str_find("awoo", cowel_regex("w"))
+\cowel_str_find("awoo", cowel_regex("o"))
+
+\cowel_str_find("αβγ", cowel_regex("β"))
+
+\cowel_str_find("", cowel_regex("x"))
+\cowel_str_find("awoo", cowel_regex("x"))
+}
+
+\test_output{
+0
+0
+
+0
+1
+2
+
+1
+
+null
+null
+}

--- a/test/semantics/str/find_str.cow
+++ b/test/semantics/str/find_str.cow
@@ -1,0 +1,27 @@
+\test_input{
+\cowel_str_find("", "")
+\cowel_str_find("awoo", "")
+
+\cowel_str_find("awoo", "a")
+\cowel_str_find("awoo", "w")
+\cowel_str_find("awoo", "o")
+
+\cowel_str_find("αβγ", "β")
+
+\cowel_str_find("", "x")
+\cowel_str_find("awoo", "x")
+}
+
+\test_output{
+0
+0
+
+0
+1
+2
+
+1
+
+null
+null
+}


### PR DESCRIPTION
This new directive matches a needle (string or regex) within a string, similar to cowel_str_contains. However, it returns the code point index of the search result instead of just a bool.

As a drive-by refactor, the Type class is modified to be non-owning rather than holding a std::vector of union alternatives, group members, etc. This was necessary to give cowel_str_contains a return type of (str | null) without dynamic initialization. In a number of other places, it allows forming unions as constexpr variables, where dynamic initialization was previously necessary.