### PR TITLE
Fix `\{` not highlighting as a directive

### DIFF
--- a/editor/vscode/package.json
+++ b/editor/vscode/package.json
@@ -63,7 +63,7 @@
           "*"
         ],
         "unbalancedBracketScopes": [
-          "constant.character.escape.bracket.cowel",
+          "constant.character.escape.cowel",
           "invalid.illegal.escape.cowel"
         ]
       }


### PR DESCRIPTION
Fix #238.