### PR TITLE
Revamp directive invocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## **[v0.8.0](https://github.com/eisenwave/cowel/releases/tag/v0.8.0)** (2026-??-??)
 
+- remove the following deprecated directives:
+  - `trim`
+- make `\d{}` call syntax equivalent to `\d({})`
 - change `null` from erroring when spliced to producing the string `"null"`
 - change numeric literals not to include a leading `-` (#233)
 - add `~`, `!`, `+`, and `-` unary prefix operators (#233)
@@ -16,6 +19,10 @@
 - fix `cowel_to_str` for base 36
 - fix crash when invoking `float`-only numeric directives (#234)
 - fix numeric bugs in `int` on native build
+- fix `cowel_not` not callable with named argument
+- fix `cowel_sqrt` and other unary numeric directives not callable with named arguments
+- fix crash (instead of error) when providing an invalid HTML attribute name
+- fix various minor documentation bugs
 
 **Full Changelog**:
 [`v0.7.0...master`](https://github.com/eisenwave/cowel/compare/v0.7.0...master)

--- a/docs/directives/misc.cow
+++ b/docs/directives/misc.cow
@@ -7,51 +7,6 @@ tags.
 It displays as a block, and its content is an HTML context.
 \cowdoc_dir{div}'s named arguments are turned into HTML attributes.
 
-\h4(id="dir-trim"){\cowdoc_dir{trim} \c{mdash} Trim input}
-
-The content of a \cowdoc_dir{text} directive is an HTML context
-(\ref("#contexts-and-output")).
-Its arguments are ignored.
-\cowdoc_dir{text} is a formatting directive.
-
-The process of \dfn{trimming} eliminates leading and trailing whitespace in the input,
-at the COWEL source level.
-
-\Bex{
-\cowblock{\literally{
-Every\trim{ day}
-}}
-This renders as:
-\Bindent{
-Every\trim{ day}
-}
-}
-
-\Btip{
-\cowdoc_dir{trim} is primarily useful inside of macros.
-We might not want to space-separate content if some of it is empty.
-For example, we could define a \cowdoc_dir{Note} macro
-where the user can \em{optionally} provide a number for that note:
-\cowblock{
-\\macro(\\Note){\\trim{Note \\put}:}
-
-\\Note Something something.
-
-\\Note{1} Something else.
-}
-This renders as:
-\Bindent{\cowel_paragraphs{
-Note: Something something.
-
-Note 1: Something else.
-}}
-Notice that because \cowdoc_dir{put} expands to no content,
-the trailing space after \cowdoc_c{Note} is eliminated.
-If it wasn't eliminated, we would end up with
-\code(cowel){\cowel_highlight_phantom{\\trim}{Note :}},
-but there should never be a space before the colon.
-}
-
 \h4(id="dir-p"){\cowdoc_dir{p} \c{mdash} Paragraphs}
 
 The \cowdoc_dir{p} directive surrounds its content in \cowdoc_html{<p>...</p>} tags.

--- a/docs/index.cow
+++ b/docs/index.cow
@@ -64,7 +64,7 @@ U+\cowel_str_to_upper(cowel_to_str(..., base=16, zpad=4))\c{nbsp}(\tt{\cowel_cha
   meta,
   (
     property = "og:\cowel_put{0}",
-    content = cowel_put{},
+    content = "\cowel_put{}",
   ),
 )\
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -1898,8 +1898,6 @@ h1 {
 <div class=toc-num data-level=4>10.13.1</div>
 <a href=#dir-div><h4><code><h- data-h=mk_tag>\div</h-></code> — Content division</h4></a>
 <div class=toc-num data-level=4>10.13.2</div>
-<a href=#dir-trim><h4><code><h- data-h=mk_tag>\trim</h-></code> — Trim input</h4></a>
-<div class=toc-num data-level=4>10.13.3</div>
 <a href=#dir-p><h4><code><h- data-h=mk_tag>\p</h-></code> — Paragraphs</h4></a>
 </div>
 
@@ -2548,7 +2546,7 @@ digits of value <math display=inline><mn>10</mn></math>..<math display=inline><m
 </p>
 <example-block><p><intro-></intro-> 
 The <g-term>int-literal</g-term> <code>0123</code> represents the integer value
-<math display=inline><mrow></mrow><mn>123</mn></math>.
+<math display=inline><mn>123</mn></math>.
 </p>
 <p>The <g-term>BINARY-INT-TOKEN</g-term> <code>0b11111111</code>,
 the <g-term>OCTAL-INT-TOKEN</g-term> <code>0o377</code>,
@@ -3822,10 +3820,6 @@ This notation consists of
     and optionally followed by '<tt->=</tt->' and a <dfn>default value</dfn>, and
   </li>
   <li>
-    optionally,
-    the symbol <tt->{...}</tt-> to indicate that the directive accepts content.
-  </li>
-  <li>
     the result type of the directive,
     separated by '<tt->:</tt->'
   </li>
@@ -3837,7 +3831,8 @@ The description of <code><h- data-h=mk_tag>\cowel_html_element</h-></code> looks
 <h- data-h=mk_tag>cowel_html_element</h->(
   <h- data-h=mk_attr>name</h->: <h- data-h=kw_type>str</h->,
   <h- data-h=mk_attr>attr</h->: <h- data-h=kw_type>lazy(group pack named string)?</h->,
-){...}: <h- data-h=kw_type>block</h->
+  <h- data-h=mk_attr>content</h->: <h- data-h=kw_type>block</h->,
+): <h- data-h=kw_type>block</h->
 </pre>
 
 <p>Or equivalently:
@@ -3845,7 +3840,8 @@ The description of <code><h- data-h=mk_tag>\cowel_html_element</h-></code> looks
 <h- data-h=mk_tag>cowel_html_element</h->(
   <h- data-h=mk_attr>name</h->: <h- data-h=kw_type>string</h->,
   <h- data-h=mk_attr>attr</h->: <h- data-h=kw_type>lazy(group(pack(named(string))))?</h->,
-){...}: <h- data-h=kw_type>block</h->
+  <h- data-h=mk_attr>content</h->: <h- data-h=kw_type>block</h->,
+): <h- data-h=kw_type>block</h->
 </pre>
 
 <p>This describes that <code><h- data-h=mk_tag>\cowel_html_element</h-></code> can be invoked as follows,
@@ -3887,8 +3883,16 @@ unless all positional arguments appear contiguously at the start of the argument
 </p>
 <ol>
   <li>
+    If a block argument is provided,
+    that argument matches the last parameter of the directive.
+    <example-block><p><intro-></intro-> 
+    The syntax <code><h- data-h=mk_tag>\</h-><h- data-h=mk_tag>d</h-><h- data-h=sym_par>(</h-><h- data-h=str>a</h-><h- data-h=sym_punc>,</h-> <h- data-h=str>b</h-><h- data-h=sym_par>)</h-><h- data-h=sym_brac>{</h->xzy<h- data-h=sym_brac>}</h-></code> is equivalent to <code><h- data-h=mk_tag>\</h-><h- data-h=mk_tag>d</h-><h- data-h=sym_par>(</h-><h- data-h=str>a</h-><h- data-h=sym_punc>,</h-> <h- data-h=str>b</h-><h- data-h=sym_punc>,</h-> <h- data-h=sym_brac>{</h->xzy<h- data-h=sym_brac>}</h-><h- data-h=sym_par>)</h-></code>.
+    </p></example-block>
+  </li>
+  <li>
     Positional arguments match parameters in the same order.
-    An error is raised if there are more positional arguments than parameters.
+    An error is raised if there are more positional arguments than parameters,
+    or if the corresponding parameter was already matched by a block argument.
   </li>
   <li>
     The following named arguments match parameters with the same name.
@@ -4045,7 +4049,8 @@ whereas '<tt->b</tt->' and '<tt->c</tt->' are discarded.
 <h- data-h=mk_tag>cowel_html_element</h->(
   <h- data-h=mk_attr>name</h->: <h- data-h=kw_type>string</h->,
   <h- data-h=mk_attr>attr</h->: <h- data-h=kw_type>lazy(group pack named string)?</h->,
-){...}: <h- data-h=kw_type>block</h->
+  <h- data-h=mk_attr>content</h->: <h- data-h=kw_type>block</h->,
+): <h- data-h=kw_type>block</h->
 </pre>
 
 <p>The <code><h- data-h=mk_tag>\cowel_html_element</h-></code> directive generates content,
@@ -4165,7 +4170,7 @@ which, in turn, feeds content into some parent content policy.
 <h4 id=dir-cowel_to_html><a class=para href=#dir-cowel_to_html></a>9.4.1. <code><h- data-h=mk_tag>\cowel_to_html</h-></code> — Process with to-HTML policy</h4>
 
 <pre>
-<h- data-h=mk_tag>cowel_to_html</h->(){...}: <h- data-h=kw_type>block</h->
+<h- data-h=mk_tag>cowel_to_html</h->(<h- data-h=mk_attr>content</h->: <h- data-h=kw_type>block</h->): <h- data-h=kw_type>block</h->
 </pre>
 
 <p><code><h- data-h=mk_tag>\cowel_to_html</h-></code> simply processes the provided content using the to-HTML policy.
@@ -4206,7 +4211,7 @@ Use of
 <h4 id=dir-cowel_no_invoke><a class=para href=#dir-cowel_no_invoke></a>9.4.2. <code><h- data-h=mk_tag>\cowel_no_invoke</h-></code> — Process with no-invoke policy</h4>
 
 <pre>
-<h- data-h=mk_tag>cowel_no_invoke</h->(){...}: <h- data-h=kw_type>block</h->
+<h- data-h=mk_tag>cowel_no_invoke</h->(<h- data-h=mk_attr>content</h->: <h- data-h=kw_type>block</h->): <h- data-h=kw_type>block</h->
 </pre>
 
 <p><code><h- data-h=mk_tag>\cowel_no_invoke</h-></code> processes the provided content
@@ -4233,7 +4238,7 @@ That is, comments are ignored, and escapes are expanded.
 <h4 id=dir-cowel_actions><a class=para href=#dir-cowel_actions></a>9.4.3. <code><h- data-h=mk_tag>\cowel_actions</h-></code> — Process with actions policy</h4>
 
 <pre>
-<h- data-h=mk_tag>cowel_actions</h->(){...}: <h- data-h=kw_type>block</h->
+<h- data-h=mk_tag>cowel_actions</h->(<h- data-h=mk_attr>content</h->: <h- data-h=kw_type>block</h->): <h- data-h=kw_type>block</h->
 </pre>
 
 <p><code><h- data-h=mk_tag>\cowel_actions</h-></code> processes the provided content
@@ -4288,7 +4293,7 @@ but macro definitions produce no output.
 <h4 id=dir-cowel_text_only><a class=para href=#dir-cowel_text_only></a>9.4.4. <code><h- data-h=mk_tag>\cowel_text_only</h-></code> — Process with text-only policy</h4>
 
 <pre>
-<h- data-h=mk_tag>cowel_text_only</h->(){...}: <h- data-h=kw_type>block</h->
+<h- data-h=mk_tag>cowel_text_only</h->(<h- data-h=mk_attr>content</h->: <h- data-h=kw_type>block</h->): <h- data-h=kw_type>block</h->
 </pre>
 
 <p><code><h- data-h=mk_tag>\cowel_text_only</h-></code> processes the provided content
@@ -4316,7 +4321,7 @@ such as in the <code>strong</code> positional argument to
 <h4 id=dir-cowel_text_as_html><a class=para href=#dir-cowel_text_as_html></a>9.4.5. <code><h- data-h=mk_tag>\cowel_text_as_html</h-></code> — Process with text-as-HTML policy</h4>
 
 <pre>
-<h- data-h=mk_tag>cowel_text_as_html</h->(){...}: <h- data-h=kw_type>block</h->
+<h- data-h=mk_tag>cowel_text_as_html</h->(<h- data-h=mk_attr>content</h->: <h- data-h=kw_type>block</h->): <h- data-h=kw_type>block</h->
 </pre>
 
 <p><code><h- data-h=mk_tag>\cowel_no_invoke</h-></code> processes the provided content
@@ -4340,7 +4345,7 @@ While there are legitimate uses (e.g. inline SVG images and other large HTML blo
 <h4 id=dir-cowel_as_text><a class=para href=#dir-cowel_as_text></a>9.4.6. <code><h- data-h=mk_tag>\cowel_as_text</h-></code> — Process with as-text policy</h4>
 
 <pre>
-<h- data-h=mk_tag>cowel_as_text</h->(){...}: <h- data-h=kw_type>block</h->
+<h- data-h=mk_tag>cowel_as_text</h->(<h- data-h=mk_attr>content</h->: <h- data-h=kw_type>block</h->): <h- data-h=kw_type>block</h->
 </pre>
 
 <p><code><h- data-h=mk_tag>\cowel_as_text</h-></code> processes the provided content
@@ -4384,7 +4389,7 @@ to render the generated HTML (rather than having it go directly into the output 
 <h4 id=dir-cowel_source_as_text><a class=para href=#dir-cowel_source_as_text></a>9.4.7. <code><h- data-h=mk_tag>\cowel_source_as_text</h-></code> — Process with source-as-text policy</h4>
 
 <pre>
-<h- data-h=mk_tag>cowel_source_as_text</h->(){...}: <h- data-h=kw_type>block</h->
+<h- data-h=mk_tag>cowel_source_as_text</h->(<h- data-h=mk_attr>content</h->: <h- data-h=kw_type>block</h->): <h- data-h=kw_type>block</h->
 </pre>
 
 <p><code><h- data-h=mk_tag>\cowel_no_invoke</h-></code> processes the provided content
@@ -4421,7 +4426,8 @@ Many examples can be found in this document.
 <pre>
 <h- data-h=mk_tag>cowel_highlight</h->(
   <h- data-h=mk_attr>lang</h->: <h- data-h=kw_type>string</h->,
-){...}: <h- data-h=kw_type>block</h->
+  <h- data-h=mk_attr>content</h->: <h- data-h=kw_type>block</h->,
+): <h- data-h=kw_type>block</h->
 </pre>
 
 <p>The <code><h- data-h=mk_tag>\cowel_highlight</h-></code>
@@ -4440,7 +4446,8 @@ which is the highlighter that COWEL uses internally.
 <pre>
 <h- data-h=mk_tag>cowel_highlight_as</h->(
   <h- data-h=mk_attr>name</h->: <h- data-h=kw_type>string</h->,
-){...}: <h- data-h=kw_type>block</h->
+  <h- data-h=mk_attr>content</h->: <h- data-h=kw_type>block</h->,
+): <h- data-h=kw_type>block</h->
 </pre>
 
 <p>The <code><h- data-h=mk_tag>\cowel_highlight_as</h-></code> directive forces certain syntax highlighting
@@ -4484,7 +4491,7 @@ Only µlight long names should be used directly.
 <h4 id=dir-cowel_highlight_phantom><a class=para href=#dir-cowel_highlight_phantom></a>9.5.3. <code><h- data-h=mk_tag>\cowel_highlight_phantom</h-></code> — Syntax highlight phantom text</h4>
 
 <pre>
-<h- data-h=mk_tag>cowel_highlight_phantom</h->(){...}: <h- data-h=kw_type>block</h->
+<h- data-h=mk_tag>cowel_highlight_phantom</h->(<h- data-h=mk_attr>content</h->: <h- data-h=kw_type>block</h->): <h- data-h=kw_type>block</h->
 </pre>
 
 <p>The <code><h- data-h=mk_tag>\cowel_highlight_phantom</h-></code> directive
@@ -4572,7 +4579,7 @@ Second paragraph.
 <h4 id=dir-cowel_paragraphs><a class=para href=#dir-cowel_paragraphs></a>9.6.2. <code><h- data-h=mk_tag>\cowel_paragraphs</h-></code> — Perform paragraph splitting</h4>
 
 <pre>
-<h- data-h=mk_tag>cowel_paragraphs</h->(){...}: <h- data-h=kw_type>block</h->
+<h- data-h=mk_tag>cowel_paragraphs</h->(<h- data-h=mk_attr>content</h->: <h- data-h=kw_type>block</h->): <h- data-h=kw_type>block</h->
 </pre>
 
 <p>The <code><h- data-h=mk_tag>\cowel_paragraphs</h-></code> directive
@@ -4796,7 +4803,8 @@ this renders as:
 <pre>
 <h- data-h=mk_tag>cowel_alias</h->(
   <h- data-h=mk_attr>names</h->: <h- data-h=kw_type>pack string</h->,
-){...}: <h- data-h=kw_type>unit</h->
+  <h- data-h=mk_attr>content</h->: <h- data-h=kw_type>block</h->,
+): <h- data-h=kw_type>unit</h->
 </pre>
 
 <p>The <code><h- data-h=mk_tag>\cowel_alias</h-></code> directive defines one or more aliases for an existing directive.
@@ -4839,7 +4847,8 @@ One or multiple aliases can be defined as follows:
 <pre>
 <h- data-h=mk_tag>cowel_macro</h->(
   <h- data-h=mk_attr>names</h->: <h- data-h=kw_type>pack string</h->,
-){...}: <h- data-h=kw_type>unit</h->
+  <h- data-h=mk_attr>content</h->: <h- data-h=kw_type>block</h->,
+): <h- data-h=kw_type>unit</h->
 </pre>
 
 <p>The <code><h- data-h=mk_tag>\cowel_macro</h-></code> directive defines a block of content which
@@ -4879,7 +4888,8 @@ may also result in paragraph splits outside the macro.
 <pre>
 <h- data-h=mk_tag>cowel_put</h->(
   <h- data-h=mk_attr>else</h->: <h- data-h=kw_type>lazy any</h->,
-){...}: <h- data-h=kw_type>any</h->
+  <h- data-h=mk_attr>content</h->: <h- data-h=kw_type>block</h->,
+): <h- data-h=kw_type>any</h->
 </pre>
 
 <p>The <code><h- data-h=mk_tag>\cowel_put</h-></code> directive processes content
@@ -5003,7 +5013,8 @@ but it can have unintended side effects:
 <pre>
 <h- data-h=mk_tag>cowel_invoke</h->(
   <h- data-h=mk_attr>name</h->: <h- data-h=kw_type>string</h->,
-){...}: <h- data-h=kw_type>any</h->
+  <h- data-h=mk_attr>content</h->: <h- data-h=kw_type>block</h->,
+): <h- data-h=kw_type>any</h->
 </pre>
 
 <p>The <code><h- data-h=mk_tag>\cowel_invoke</h-></code> directive invokes a directive by name.
@@ -7074,48 +7085,7 @@ tags.
 It displays as a block, and its content is an HTML context.
 <code><h- data-h=mk_tag>\div</h-></code>'s named arguments are turned into HTML attributes.
 </p>
-<h4 id=dir-trim><a class=para href=#dir-trim></a>10.13.2. <code><h- data-h=mk_tag>\trim</h-></code> — Trim input</h4>
-
-<p>The content of a <code><h- data-h=mk_tag>\text</h-></code> directive is an HTML context
-(<a href=#contexts-and-output>§5.1. Content policies</a>).
-Its arguments are ignored.
-<code><h- data-h=mk_tag>\text</h-></code> is a formatting directive.
-</p>
-<p>The process of <dfn>trimming</dfn> eliminates leading and trailing whitespace in the input,
-at the COWEL source level.
-</p>
-<example-block><p><intro-></intro-> 
-</p><code-block>Every<h- data-h=mk_tag>\trim</h-><h- data-h=sym_brac>{</h-> day<h- data-h=sym_brac>}</h-></code-block>
-<p>This renders as:
-</p><div class=indent>
-Everyday
-</div>
-</example-block>
-
-<tip-block><p><intro-></intro-> 
-<code><h- data-h=mk_tag>\trim</h-></code> is primarily useful inside of macros.
-We might not want to space-separate content if some of it is empty.
-For example, we could define a <code><h- data-h=mk_tag>\Note</h-></code> macro
-where the user can <em>optionally</em> provide a number for that note:
-</p><code-block><h- data-h=mk_tag>\</h-><h- data-h=mk_tag>macro</h-><h- data-h=sym_par>(</h->\Note<h- data-h=sym_par>)</h-><h- data-h=sym_brac>{</h-><h- data-h=mk_tag>\</h-><h- data-h=mk_tag>trim</h-><h- data-h=sym_brac>{</h->Note <h- data-h=mk_tag>\</h-><h- data-h=mk_tag>put</h-><h- data-h=sym_brac>}</h->:<h- data-h=sym_brac>}</h->
-
-<h- data-h=mk_tag>\</h-><h- data-h=mk_tag>Note</h-> Something something.
-
-<h- data-h=mk_tag>\</h-><h- data-h=mk_tag>Note</h-><h- data-h=sym_brac>{</h->1<h- data-h=sym_brac>}</h-> Something else.</code-block>
-<p>This renders as:
-</p><div class=indent>
-<p>Note: Something something.
-</p>
-<p>Note 1: Something else.
-</p></div>
-<p>Notice that because <code><h- data-h=mk_tag>\put</h-></code> expands to no content,
-the trailing space after <code>Note</code> is eliminated.
-If it wasn't eliminated, we would end up with
-<code><h- data-h=sym_brac>{</h->Note :<h- data-h=sym_brac>}</h-></code>,
-but there should never be a space before the colon.
-</p></tip-block>
-
-<h4 id=dir-p><a class=para href=#dir-p></a>10.13.3. <code><h- data-h=mk_tag>\p</h-></code> — Paragraphs</h4>
+<h4 id=dir-p><a class=para href=#dir-p></a>10.13.2. <code><h- data-h=mk_tag>\p</h-></code> — Paragraphs</h4>
 
 <p>The <code><h- data-h=mk_tag>\p</h-></code> directive surrounds its content in <code><h- data-h=sym_punc>&lt;</h-><h- data-h=mk_tag>p</h-><h- data-h=sym_punc>&gt;</h->...<h- data-h=sym_punc>&lt;/</h-><h- data-h=mk_tag>p</h-><h- data-h=sym_punc>&gt;</h-></code> tags.
 </p></main></body>

--- a/docs/intro/syntax.cow
+++ b/docs/intro/syntax.cow
@@ -167,9 +167,9 @@ The meaning of the escape sequences is described in the table below.
   }
   \tr{
     \td{
-      \nobr{\cowdoc_esc U+000A LINE FEED},
-      \nobr{\cowdoc_esc U+000D CARRIAGE RETURN},
-      \nobr{\cowdoc_esc U+000A U+000D (CRLF escape)}
+      \nobr{\cowdoc_esc{} U+000A LINE FEED},
+      \nobr{\cowdoc_esc{} U+000D CARRIAGE RETURN},
+      \nobr{\cowdoc_esc{} U+000A U+000D (CRLF escape)}
     }
     \td{
       Expands to nothing.
@@ -395,7 +395,7 @@ Leading zeros are ignored.
 
 \Bex{
 The \gterm{int-literal} \cowdoc_c{0123} represents the integer value
-\math{\mrow\mn{123}}.
+\math{\mn{123}}.
 
 The \gterm{BINARY-INT-TOKEN} \cowdoc_c{0b11111111},
 the \gterm{OCTAL-INT-TOKEN} \cowdoc_c{0o377},

--- a/docs/new_directives.cow
+++ b/docs/new_directives.cow
@@ -50,10 +50,6 @@ This notation consists of
     and optionally followed by '\tt{=}' and a \dfn{default value}, and
   }
   \li{
-    optionally,
-    the symbol \tt{{...}} to indicate that the directive accepts content.
-  }
-  \li{
     the result type of the directive,
     separated by '\tt{:}'
   }
@@ -65,7 +61,8 @@ The description of \cowdoc_dir{cowel_html_element} looks as follows:
 \cowel_highlight_as("markup-tag"){cowel_html_element}(
   \cowdoc_param("name", "str"),
   \cowdoc_param("attr", "lazy(group pack named string)?"),
-){...}: \cowel_highlight_as("keyword-type"){block}
+  \cowdoc_param("content", "block"),
+): \cowel_highlight_as("keyword-type"){block}
 }
 
 Or equivalently:
@@ -73,7 +70,8 @@ Or equivalently:
 \cowel_highlight_as("markup-tag"){cowel_html_element}(
   \cowdoc_param("name", "string"),
   \cowdoc_param("attr", "lazy(group(pack(named(string))))?"),
-){...}: \cowel_highlight_as("keyword-type"){block}
+  \cowdoc_param("content", "block"),
+): \cowel_highlight_as("keyword-type"){block}
 }
 
 This describes that \cowdoc_dir{cowel_html_element} can be invoked as follows,
@@ -119,8 +117,16 @@ The usual argument matching is performed as follows:
 
 \ol{
   \li{
+    If a block argument is provided,
+    that argument matches the last parameter of the directive.
+    \Bex{
+    The syntax \cowdoc_c{\\d(a, b){xzy}} is equivalent to \cowdoc_c{\\d(a, b, {xzy})}.
+    }
+  }
+  \li{
     Positional arguments match parameters in the same order.
-    An error is raised if there are more positional arguments than parameters.
+    An error is raised if there are more positional arguments than parameters,
+    or if the corresponding parameter was already matched by a block argument.
   }
   \li{
     The following named arguments match parameters with the same name.
@@ -297,7 +303,8 @@ whereas '\tt{b}' and '\tt{c}' are discarded.
 \cowel_highlight_as("markup-tag"){cowel_html_element}(
   \cowdoc_param("name", "string"),
   \cowdoc_param("attr", "lazy(group pack named string)?"),
-){...}: \cowel_highlight_as("keyword-type"){block}
+  \cowdoc_param("content", "block"),
+): \cowel_highlight_as("keyword-type"){block}
 }
 
 The \cowdoc_dir{cowel_html_element} directive generates content,
@@ -429,7 +436,7 @@ The table below lists directives which process content using some content policy
 ){\cowdoc_dir{cowel_to_html} \c{mdash} Process with to-HTML policy}
 
 \pre{
-\cowel_highlight_as("markup-tag"){cowel_to_html}(){...}: \cowel_highlight_as("keyword-type"){block}
+\cowel_highlight_as("markup-tag"){cowel_to_html}(\cowdoc_param("content", "block")): \cowel_highlight_as("keyword-type"){block}
 }
 
 \cowdoc_dir{cowel_to_html} simply processes the provided content using the to-HTML policy.
@@ -474,7 +481,7 @@ Use of
 ){\cowdoc_dir{cowel_no_invoke} \c{mdash} Process with no-invoke policy}
 
 \pre{
-\cowel_highlight_as("markup-tag"){cowel_no_invoke}(){...}: \cowel_highlight_as("keyword-type"){block}
+\cowel_highlight_as("markup-tag"){cowel_no_invoke}(\cowdoc_param("content", "block")): \cowel_highlight_as("keyword-type"){block}
 }
 
 \cowdoc_dir{cowel_no_invoke} processes the provided content
@@ -507,7 +514,7 @@ That is, comments are ignored, and escapes are expanded.
 ){\cowdoc_dir{cowel_actions} \c{mdash} Process with actions policy}
 
 \pre{
-\cowel_highlight_as("markup-tag"){cowel_actions}(){...}: \cowel_highlight_as("keyword-type"){block}
+\cowel_highlight_as("markup-tag"){cowel_actions}(\cowdoc_param("content", "block")): \cowel_highlight_as("keyword-type"){block}
 }
 
 \cowdoc_dir{cowel_actions} processes the provided content
@@ -568,7 +575,7 @@ but macro definitions produce no output.
 ){\cowdoc_dir{cowel_text_only} \c{mdash} Process with text-only policy}
 
 \pre{
-\cowel_highlight_as("markup-tag"){cowel_text_only}(){...}: \cowel_highlight_as("keyword-type"){block}
+\cowel_highlight_as("markup-tag"){cowel_text_only}(\cowdoc_param("content", "block")): \cowel_highlight_as("keyword-type"){block}
 }
 
 \cowdoc_dir{cowel_text_only} processes the provided content
@@ -602,7 +609,7 @@ It is mainly useful in situations where it makes no sense to have non-plaintext 
 ){\cowdoc_dir{cowel_text_as_html} \c{mdash} Process with text-as-HTML policy}
 
 \pre{
-\cowel_highlight_as("markup-tag"){cowel_text_as_html}(){...}: \cowel_highlight_as("keyword-type"){block}
+\cowel_highlight_as("markup-tag"){cowel_text_as_html}(\cowdoc_param("content", "block")): \cowel_highlight_as("keyword-type"){block}
 }
 
 \cowdoc_dir{cowel_no_invoke} processes the provided content
@@ -632,7 +639,7 @@ While there are legitimate uses (e.g. inline SVG images and other large HTML blo
 ){\cowdoc_dir{cowel_as_text} \c{mdash} Process with as-text policy}
 
 \pre{
-\cowel_highlight_as("markup-tag"){cowel_as_text}(){...}: \cowel_highlight_as("keyword-type"){block}
+\cowel_highlight_as("markup-tag"){cowel_as_text}(\cowdoc_param("content", "block")): \cowel_highlight_as("keyword-type"){block}
 }
 
 \cowdoc_dir{cowel_as_text} processes the provided content
@@ -682,7 +689,7 @@ to render the generated HTML (rather than having it go directly into the output 
 ){\cowdoc_dir{cowel_source_as_text} \c{mdash} Process with source-as-text policy}
 
 \pre{
-\cowel_highlight_as("markup-tag"){cowel_source_as_text}(){...}: \cowel_highlight_as("keyword-type"){block}
+\cowel_highlight_as("markup-tag"){cowel_source_as_text}(\cowdoc_param("content", "block")): \cowel_highlight_as("keyword-type"){block}
 }
 
 \cowdoc_dir{cowel_no_invoke} processes the provided content
@@ -725,7 +732,8 @@ Many examples can be found in this document.
 \pre{
 \cowel_highlight_as("markup-tag"){cowel_highlight}(
   \cowdoc_param("lang", "string"),
-){...}: \cowel_highlight_as("keyword-type"){block}
+  \cowdoc_param("content", "block"),
+): \cowel_highlight_as("keyword-type"){block}
 }
 
 The \cowdoc_dir{cowel_highlight}
@@ -746,7 +754,8 @@ which is the highlighter that COWEL uses internally.
 \pre{
 \cowel_highlight_as("markup-tag"){cowel_highlight_as}(
   \cowdoc_param("name", "string"),
-){...}: \cowel_highlight_as("keyword-type"){block}
+  \cowdoc_param("content", "block"),
+): \cowel_highlight_as("keyword-type"){block}
 }
 
 The \cowdoc_dir{cowel_highlight_as} directive forces certain syntax highlighting
@@ -796,7 +805,7 @@ Only µlight long names should be used directly.
 ){\cowdoc_dir{cowel_highlight_phantom} \c{mdash} Syntax highlight phantom text}
 
 \pre{
-\cowel_highlight_as("markup-tag"){cowel_highlight_phantom}(){...}: \cowel_highlight_as("keyword-type"){block}
+\cowel_highlight_as("markup-tag"){cowel_highlight_phantom}(\cowdoc_param("content", "block")): \cowel_highlight_as("keyword-type"){block}
 }
 
 The \cowdoc_dir{cowel_highlight_phantom} directive
@@ -894,7 +903,7 @@ Generated HTML:
 ){\cowdoc_dir{cowel_paragraphs} \c{mdash} Perform paragraph splitting}
 
 \pre{
-\cowel_highlight_as("markup-tag"){cowel_paragraphs}(){...}: \cowel_highlight_as("keyword-type"){block}
+\cowel_highlight_as("markup-tag"){cowel_paragraphs}(\cowdoc_param("content", "block")): \cowel_highlight_as("keyword-type"){block}
 }
 
 The \cowdoc_dir{cowel_paragraphs} directive
@@ -1150,7 +1159,8 @@ this renders as:
 \pre{
 \cowel_highlight_as("markup-tag"){cowel_alias}(
   \cowdoc_param("names", "pack string"),
-){...}: \cowel_highlight_as("keyword-type"){unit}
+  \cowdoc_param("content", "block"),
+): \cowel_highlight_as("keyword-type"){unit}
 }
 
 The \cowdoc_dir{cowel_alias} directive defines one or more aliases for an existing directive.
@@ -1197,7 +1207,8 @@ One or multiple aliases can be defined as follows:
 \pre{
 \cowel_highlight_as("markup-tag"){cowel_macro}(
   \cowdoc_param("names", "pack string"),
-){...}: \cowel_highlight_as("keyword-type"){unit}
+  \cowdoc_param("content", "block"),
+): \cowel_highlight_as("keyword-type"){unit}
 }
 
 The \cowdoc_dir{cowel_macro} directive defines a block of content which
@@ -1243,7 +1254,8 @@ may also result in paragraph splits outside the macro.
 \pre{
 \cowel_highlight_as("markup-tag"){cowel_put}(
   \cowdoc_param("else", "lazy any"),
-){...}: \cowel_highlight_as("keyword-type"){any}
+  \cowdoc_param("content", "block"),
+): \cowel_highlight_as("keyword-type"){any}
 }
 
 The \cowdoc_dir{cowel_put} directive processes content
@@ -1383,7 +1395,8 @@ but it can have unintended side effects:
 \pre{
 \cowel_highlight_as("markup-tag"){cowel_invoke}(
   \cowdoc_param("name", "string"),
-){...}: \cowel_highlight_as("keyword-type"){any}
+  \cowdoc_param("content", "block"),
+): \cowel_highlight_as("keyword-type"){any}
 }
 
 The \cowdoc_dir{cowel_invoke} directive invokes a directive by name.

--- a/include/cowel/ast.hpp
+++ b/include/cowel/ast.hpp
@@ -240,7 +240,7 @@ public:
     }
 
     [[nodiscard]]
-    File_Source_Span get_source_span() const
+    const File_Source_Span& get_source_span() const
     {
         return m_source_span;
     }
@@ -405,7 +405,7 @@ public:
     }
 
     [[nodiscard]]
-    File_Source_Span get_source_span() const
+    const File_Source_Span& get_source_span() const
     {
         return m_source_span;
     }
@@ -503,7 +503,7 @@ public:
     }
 
     [[nodiscard]]
-    File_Source_Span get_source_span() const
+    const File_Source_Span& get_source_span() const
     {
         return m_source_span;
     }
@@ -576,28 +576,6 @@ struct Expression : Expression_Variant {
     }
 
     [[nodiscard]]
-    bool is_spliceable_value() const noexcept
-    {
-        // FIXME: This doesn't seem correct;
-        //        directives can return `group`,
-        //        and aren't necessarily spliceable.
-        return is_directive() //
-            || (is_primary() && as_primary().is_spliceable_value())
-            || (is_unary() && as_unary().get_operand().is_spliceable_value());
-    }
-
-    [[nodiscard]]
-    bool is_spliceable() const noexcept
-    {
-        // FIXME: This doesn't seem correct;
-        //        directives can return `group`,
-        //        and aren't necessarily spliceable.
-        return is_directive() //
-            || (is_primary() && as_primary().is_spliceable())
-            || (is_unary() && as_unary().get_operand().is_spliceable());
-    }
-
-    [[nodiscard]]
     bool is_value() const noexcept
     {
         return is_directive() //
@@ -606,10 +584,10 @@ struct Expression : Expression_Variant {
     }
 
     [[nodiscard]]
-    File_Source_Span get_source_span() const
+    const File_Source_Span& get_source_span() const
     {
         return std::visit(
-            [&](const auto& v) -> File_Source_Span { return v.get_source_span(); }, *this
+            [&](const auto& v) -> const File_Source_Span& { return v.get_source_span(); }, *this
         );
     }
 
@@ -648,16 +626,16 @@ public:
 private:
     File_Source_Span m_source_span;
     std::u8string_view m_source;
-    std::optional<Primary> m_name;
-    std::optional<Expression> m_value;
+    GC_Ref<Primary> m_name;
+    GC_Ref<Expression> m_value;
     Member_Kind m_kind;
 
     [[nodiscard]]
     Group_Member(
         const File_Source_Span& source_span,
         std::u8string_view source,
-        std::optional<Primary>&& name,
-        std::optional<Expression>&& value,
+        GC_Ref<Primary> name,
+        GC_Ref<Expression> value,
         Member_Kind type
     );
 
@@ -679,7 +657,7 @@ public:
     }
 
     [[nodiscard]]
-    File_Source_Span get_source_span() const
+    const File_Source_Span& get_source_span() const
     {
         return m_source_span;
     }
@@ -693,14 +671,19 @@ public:
     [[nodiscard]]
     bool has_name() const
     {
-        return m_name.has_value();
+        return bool(m_name);
     }
 
     [[nodiscard]]
     const Primary& get_name() const
     {
         COWEL_ASSERT(m_kind == Member_Kind::named);
-        return m_name.value();
+        return *m_name;
+    }
+    [[nodiscard]]
+    GC_Ref<const Primary> get_name_ref() const
+    {
+        return m_name;
     }
 
     [[nodiscard]]
@@ -712,13 +695,18 @@ public:
     [[nodiscard]]
     bool has_value() const
     {
-        return m_value.has_value();
+        return bool(m_value);
     }
 
     [[nodiscard]]
     const Expression& get_value() const
     {
-        return m_value.value();
+        return *m_value;
+    }
+    [[nodiscard]]
+    GC_Ref<const Expression> get_value_ref() const
+    {
+        return m_value;
     }
 
     [[nodiscard]]

--- a/include/cowel/builtin_directive_set.hpp
+++ b/include/cowel/builtin_directive_set.hpp
@@ -642,22 +642,6 @@ struct Var_Delete_Behavior final : Unit_Directive_Behavior {
     Processing_Status do_evaluate(const Invocation& call, Context& context) const final;
 };
 
-struct Trim_Behavior : Block_Directive_Behavior {
-protected:
-    const Directive_Display m_display;
-
-public:
-    [[nodiscard]]
-    constexpr explicit Trim_Behavior(Directive_Display display)
-        : m_display { display }
-    {
-    }
-
-    [[nodiscard]]
-    Processing_Status
-    splice(Content_Policy& out, const Invocation& call, Context& context) const override;
-};
-
 struct Passthrough_Behavior : Block_Directive_Behavior {
 protected:
     const Policy_Usage m_policy;
@@ -944,6 +928,8 @@ struct Macro_Behavior final : Unit_Directive_Behavior {
     Processing_Status do_evaluate(const Invocation&, Context&) const override;
 };
 
+struct Argument;
+
 struct Put_Behavior final : Directive_Behavior {
 
     [[nodiscard]]
@@ -960,7 +946,7 @@ struct Put_Behavior final : Directive_Behavior {
 
 private:
     [[nodiscard]]
-    Result<const ast::Expression*, Processing_Status> resolve(const Invocation&, Context&) const;
+    Result<Argument, Processing_Status> resolve(const Invocation&, Context&) const;
 };
 
 struct Paragraph_Enter_Behavior final : Block_Directive_Behavior {

--- a/include/cowel/collecting_logger.hpp
+++ b/include/cowel/collecting_logger.hpp
@@ -67,6 +67,7 @@ private:
     const std::u8string_view m_expected_id;
     bool m_expected_logged = false;
     std::pmr::vector<Collected_Diagnostic> m_violations;
+    std::pmr::vector<Collected_Diagnostic> m_extra;
 
 public:
     explicit Expecting_Logger(
@@ -88,6 +89,12 @@ public:
         return m_violations;
     }
 
+    [[nodiscard]]
+    std::span<const Collected_Diagnostic> get_extra_diagnostics() const
+    {
+        return m_extra;
+    }
+
     void operator()(const Diagnostic diagnostic) override
     {
         std::pmr::vector<char8_t> id_data;
@@ -97,13 +104,17 @@ public:
             m_expected_logged = true;
             return;
         }
+        std::pmr::memory_resource* const memory = m_violations.get_allocator().resource();
         // Additional warnings or errors are not considered a violation,
         // but getting anything with greater severity should not happen.
-        if (diagnostic.severity > m_expected_severity) {
-            static_assert(std::is_trivially_copyable_v<Diagnostic>);
-            std::pmr::memory_resource* const memory = m_violations.get_allocator().resource();
-            m_violations.emplace_back(diagnostic, memory);
-        }
+        auto& target = diagnostic.severity > m_expected_severity ? m_violations : m_extra;
+
+        static_assert(
+            std::is_trivially_copyable_v<Diagnostic>,
+            "emplace_back is expected to perform a trivial copy. "
+            "A design change is needed if that is not possible."
+        );
+        target.emplace_back(diagnostic, memory);
     }
 
     [[nodiscard]]

--- a/include/cowel/diagnostic.hpp
+++ b/include/cowel/diagnostic.hpp
@@ -69,8 +69,8 @@ inline constexpr std::u8string_view directive_lookup_unresolved = u8"directive-l
 /// @brief Duplicate arguments to a directive were provided.
 inline constexpr std::u8string_view duplicate_args = u8"duplicate.args";
 
-/// @brief The content of a directive was ignored.
-inline constexpr std::u8string_view ignored_content = u8"ignored.content";
+/// @brief Some input was ignored.
+inline constexpr std::u8string_view ignored_input = u8"ignored.input";
 
 /// @brief Parse error.
 inline constexpr std::u8string_view parse = u8"parse";
@@ -131,6 +131,9 @@ inline constexpr std::u8string_view splice = u8"splice";
 /// @brief In an HTML element directive,
 /// the provided tag name is invalid.
 inline constexpr std::u8string_view html_element_name_invalid = u8"html.element.name.invalid";
+
+/// @brief Invalid HTML attribute name.
+inline constexpr std::u8string_view html_attribute = u8"html.attribute";
 
 /// @brief In a `\cowel_include` directive,
 /// no file path was provided.

--- a/include/cowel/directive_processing.hpp
+++ b/include/cowel/directive_processing.hpp
@@ -177,6 +177,7 @@ Processing_Status splice_primary(
     Context& context
 );
 
+[[nodiscard]]
 Processing_Status splice_value_to_plaintext(
     std::pmr::vector<char8_t>& out, //
     const Value& value,
@@ -253,14 +254,6 @@ const Type& get_static_type(const ast::Directive& directive, Context& context);
 const Type& get_type(const ast::Primary& primary);
 
 [[nodiscard]]
-Processing_Status splice_all_trimmed(
-    Content_Policy& out,
-    std::span<const ast::Markup_Element> content,
-    Frame_Index,
-    Context& context
-);
-
-[[nodiscard]]
 Processing_Status splice_to_plaintext(
     std::pmr::vector<char8_t>& out,
     std::span<const ast::Markup_Element> content,
@@ -297,13 +290,6 @@ enum struct Paragraphs_State : bool {
     inside,
 };
 
-[[nodiscard]]
-Processing_Status match_empty_arguments(
-    const Invocation& call,
-    Context& context,
-    Processing_Status fail_status = Processing_Status::error
-);
-
 void diagnose(
     Syntax_Highlight_Error error,
     std::u8string_view lang,
@@ -311,7 +297,7 @@ void diagnose(
     Context& context
 );
 
-[[nodiscard]]
+[[nodiscard, deprecated]]
 Processing_Status named_arguments_to_attributes(
     Text_Buffer_Attribute_Writer& out,
     std::span<const ast::Group_Member> arguments,
@@ -320,11 +306,34 @@ Processing_Status named_arguments_to_attributes(
     Attribute_Style style = Attribute_Style::double_if_needed
 );
 
-[[nodiscard]]
+[[nodiscard, deprecated]]
 Processing_Status named_argument_to_attribute(
     Text_Buffer_Attribute_Writer& out,
     const ast::Group_Member& a,
     Frame_Index frame,
+    Context& context,
+    Attribute_Style style = Attribute_Style::double_if_needed
+);
+
+Result<void, std::size_t> named_str_arguments_to_attributes(
+    Text_Buffer_Attribute_Writer& out,
+    std::span<const Group_Member_Value> arguments,
+    Attribute_Style style = Attribute_Style::double_if_needed
+);
+
+struct Group_Pack_Named_Str_Matcher;
+struct Pack_Named_Of_Type_Matcher;
+
+Processing_Status named_arguments_to_attributes_or_error(
+    Text_Buffer_Attribute_Writer& out,
+    const Group_Pack_Named_Str_Matcher& matcher,
+    Context& context,
+    Attribute_Style style = Attribute_Style::double_if_needed
+);
+
+Processing_Status named_arguments_to_attributes_or_error(
+    Text_Buffer_Attribute_Writer& out,
+    const Pack_Named_Of_Type_Matcher& matcher,
     Context& context,
     Attribute_Style style = Attribute_Style::double_if_needed
 );

--- a/include/cowel/directive_processing.hpp
+++ b/include/cowel/directive_processing.hpp
@@ -297,24 +297,6 @@ void diagnose(
     Context& context
 );
 
-[[nodiscard, deprecated]]
-Processing_Status named_arguments_to_attributes(
-    Text_Buffer_Attribute_Writer& out,
-    std::span<const ast::Group_Member> arguments,
-    Frame_Index frame,
-    Context& context,
-    Attribute_Style style = Attribute_Style::double_if_needed
-);
-
-[[nodiscard, deprecated]]
-Processing_Status named_argument_to_attribute(
-    Text_Buffer_Attribute_Writer& out,
-    const ast::Group_Member& a,
-    Frame_Index frame,
-    Context& context,
-    Attribute_Style style = Attribute_Style::double_if_needed
-);
-
 Result<void, std::size_t> named_str_arguments_to_attributes(
     Text_Buffer_Attribute_Writer& out,
     std::span<const Group_Member_Value> arguments,

--- a/include/cowel/gc.hpp
+++ b/include/cowel/gc.hpp
@@ -112,18 +112,23 @@ struct GC_Node {
     }
 };
 
-template <class T>
+template <typename T>
 struct GC_Allocation {
     GC_Node node;
     alignas(T) unsigned char storage[sizeof(T)] {};
 };
 
-template <class T>
+template <typename T>
 struct GC_Ref;
 
-template <class T>
+template <typename T>
 struct GC_Ref {
 private:
+    // All other GC_Refs are friends.
+    // This is necessary for converting constructors.
+    template <typename U>
+    friend struct GC_Ref;
+
     GC_Node* m_node = nullptr;
 
 public:
@@ -148,6 +153,18 @@ public:
             COWEL_ASSERT(align >= alignof(T));
             COWEL_ASSERT((align & (align - 1)) == 0);
         }
+    }
+
+    [[nodiscard]]
+    constexpr GC_Ref(GC_Ref<std::remove_const_t<T>> other) noexcept
+        requires std::is_const_v<T>
+        : m_node { other.unsafe_release_node() }
+    {
+        // This conversion is safe because GC_Node is type-erased
+        // and performs destruction using the original type's destructor.
+        // As long as we don't violate strict aliasing and conversion of the pointer
+        // doesn't require address adjustment,
+        // we can "reinterpret" a GC_Ref.
     }
 
     [[nodiscard]]

--- a/include/cowel/gc.hpp
+++ b/include/cowel/gc.hpp
@@ -155,9 +155,10 @@ public:
         }
     }
 
-    [[nodiscard]]
-    constexpr GC_Ref(GC_Ref<std::remove_const_t<T>> other) noexcept
+    template <std::same_as<std::remove_const_t<T>> U>
         requires std::is_const_v<T>
+    [[nodiscard]]
+    constexpr GC_Ref(GC_Ref<U> other) noexcept
         : m_node { other.unsafe_release_node() }
     {
         // This conversion is safe because GC_Node is type-erased

--- a/include/cowel/parameters.hpp
+++ b/include/cowel/parameters.hpp
@@ -10,6 +10,7 @@
 
 #include "cowel/util/char_sequence.hpp"
 #include "cowel/util/function_ref.hpp"
+#include "cowel/util/small_vector.hpp"
 #include "cowel/util/source_position.hpp"
 #include "cowel/util/strings.hpp"
 
@@ -63,112 +64,165 @@ consteval Fail_Callback make_fail_callback() noexcept
     return { const_v<lambda> };
 }
 
-// VALUE ===========================================================================================
-
-struct Value_Matcher : virtual Was_Matched {
+struct Argument {
+public:
     [[nodiscard]]
-    explicit Value_Matcher()
-        : Was_Matched {}
+    static Argument positional(const ast::Group_Member& member)
+    {
+        COWEL_ASSERT(member.get_kind() == ast::Member_Kind::positional);
+        return { Value::null, member };
+    }
+
+    [[nodiscard]]
+    static Argument block(const ast::Primary& primary)
+    {
+        COWEL_ASSERT(primary.get_kind() == ast::Primary_Kind::block);
+        return Argument { primary };
+    }
+
+    [[nodiscard]]
+    static Argument named(Value name, const ast::Group_Member& member)
+    {
+        COWEL_ASSERT(member.get_kind() == ast::Member_Kind::named);
+        return { std::move(name), member };
+    }
+
+private:
+    static Result<Value, Processing_Status>
+    group_member_evaluate(const void*, Frame_Index, Context&);
+    static Processing_Status group_member_splice(
+        const void*, //
+        Content_Policy&,
+        Frame_Index,
+        Context&
+    );
+    static Processing_Status group_member_splice_to_plaintext(
+        const void*, //
+        std::pmr::vector<char8_t>& out,
+        Frame_Index,
+        Context&
+    );
+    static const File_Source_Span& group_member_get_source_span(const void*) noexcept;
+    static const Type& group_member_get_static_type(const void*, Context&) noexcept;
+
+    static Result<Value, Processing_Status> primary_evaluate(const void*, Frame_Index, Context&);
+    static Processing_Status primary_splice(
+        const void*, //
+        Content_Policy&,
+        Frame_Index,
+        Context&
+    );
+    static Processing_Status primary_splice_to_plaintext(
+        const void*, //
+        std::pmr::vector<char8_t>& out,
+        Frame_Index,
+        Context&
+    );
+    static const File_Source_Span& primary_get_source_span(const void*) noexcept;
+    static const Type& primary_get_static_type(const void*, Context&) noexcept;
+
+    /// @brief The evaluated argument name (in the case of named arguments),
+    /// or `null` in the case of positional arguments.
+    Value m_name;
+    /// @brief A type-erased reference to the AST node.
+    const void* m_ast_node = nullptr;
+    Result<Value, Processing_Status> (*m_evaluate)(const void*, Frame_Index, Context&) = nullptr;
+    Processing_Status (*m_splice)(const void*, Content_Policy&, Frame_Index, Context&) = nullptr;
+    Processing_Status (*m_splice_to_plaintext)(
+        const void*,
+        std::pmr::vector<char8_t>&,
+        Frame_Index,
+        Context&
+    ) = nullptr;
+    const File_Source_Span& (*m_get_value_location)(const void*) noexcept = nullptr;
+    const Type& (*m_get_static_type)(const void*, Context&) noexcept = nullptr;
+    /// @brief The location of the argument as a whole.
+    /// Unlike the location of the expression,
+    /// this also includes the argument name.
+    File_Source_Span m_location;
+
+    [[nodiscard]]
+    Argument(Value name, const ast::Group_Member& arg) noexcept
+        : m_name { std::move(name) }
+        , m_ast_node { &arg }
+        , m_evaluate { group_member_evaluate }
+        , m_splice { group_member_splice }
+        , m_splice_to_plaintext { group_member_splice_to_plaintext }
+        , m_get_value_location { group_member_get_source_span }
+        , m_get_static_type { group_member_get_static_type }
+        , m_location { arg.get_source_span() }
     {
     }
 
-    /// @brief Attempts matching the value contained in `argument`
-    /// according to this matcher's behavior.
-    /// @param argument The argument to match.
-    /// @param frame The frame index of the argument.
-    /// @param context The current context.
-    /// @return A `Processing_Status` if content generation failed during the matching process.
     [[nodiscard]]
-    virtual Processing_Status match_value(
-        const ast::Expression& argument,
-        Frame_Index frame,
-        Context& context,
-        const Match_Fail_Options& on_fail
-    ) = 0;
-};
-
-/// @brief Matches a lazy value of single specific kind.
-/// This is typically used for blocks and quoted strings.
-struct Lazy_Value_Of_Type_Matcher final : Value_Matcher {
-private:
-    const Type* m_expected_type;
-    const ast::Expression* m_markup = nullptr;
-    Frame_Index m_markup_frame { -2 };
+    explicit Argument(const ast::Primary& arg) noexcept
+        : m_name { Value::null }
+        , m_ast_node { &arg }
+        , m_evaluate { primary_evaluate }
+        , m_splice { primary_splice }
+        , m_splice_to_plaintext { primary_splice_to_plaintext }
+        , m_get_value_location { primary_get_source_span }
+        , m_get_static_type { primary_get_static_type }
+        , m_location { arg.get_source_span() }
+    {
+    }
 
 public:
     [[nodiscard]]
-    explicit Lazy_Value_Of_Type_Matcher(const Type* expected_type)
-        : m_expected_type { expected_type }
-    {
-        COWEL_ASSERT(expected_type);
-    }
-
-    [[nodiscard]]
-    bool was_matched() const override
-    {
-        return m_markup != nullptr;
-    }
-
-    void reset() noexcept override
-    {
-        m_markup = nullptr;
-    }
-
-    [[nodiscard]]
-    const ast::Expression& get() const
-    {
-        COWEL_ASSERT(was_matched());
-        return *m_markup;
-    }
-
-    [[nodiscard]]
-    const Type& get_expected_type() const
-    {
-        return *m_expected_type;
-    }
-
-    [[nodiscard]]
-    Frame_Index get_frame() const
-    {
-        return m_markup_frame;
-    }
-
-    [[nodiscard]]
-    const ast::Expression* get_or_null() const
-    {
-        return m_markup;
-    }
-
-    [[nodiscard]]
-    Processing_Status match_value(
-        const ast::Expression& argument,
-        Frame_Index frame,
-        Context&,
-        const Match_Fail_Options& //
-    ) override;
-};
-
-struct Textual_Matcher : Value_Matcher {
-
-    [[nodiscard]]
-    explicit Textual_Matcher()
+    Argument()
         = default;
 
     [[nodiscard]]
-    Processing_Status match_value(
-        const ast::Expression& argument,
-        Frame_Index frame,
-        Context& context,
-        const Match_Fail_Options& on_fail
-    ) override;
+    const Value& get_name() const
+    {
+        return m_name;
+    }
+    [[nodiscard]]
+    const File_Source_Span& get_location() const
+    {
+        return m_location;
+    }
 
     [[nodiscard]]
-    virtual bool match_string(
-        const ast::Expression& argument,
-        std::u8string_view str,
-        Context& context,
-        Fail_Callback on_fail
-    ) = 0;
+    Result<Value, Processing_Status> evaluate(const Frame_Index frame, Context& context) const
+    {
+        return m_evaluate(m_ast_node, frame, context);
+    }
+    [[nodiscard]]
+    Processing_Status splice(Content_Policy& out, const Frame_Index frame, Context& context) const
+    {
+        return m_splice(m_ast_node, out, frame, context);
+    }
+    [[nodiscard]]
+    Processing_Status splice_to_plaintext(
+        std::pmr::vector<char8_t>& out,
+        const Frame_Index frame,
+        Context& context
+    ) const
+    {
+        return m_splice_to_plaintext(m_ast_node, out, frame, context);
+    }
+    [[nodiscard]]
+    const File_Source_Span& get_value_location() const
+    {
+        return m_get_value_location(m_ast_node);
+    }
+    [[nodiscard]]
+    const Type& get_static_type(Context& context) const
+    {
+        return m_get_static_type(m_ast_node, context);
+    }
+
+    [[nodiscard]]
+    constexpr bool is_named() const
+    {
+        return !m_name.is_null();
+    }
+    [[nodiscard]]
+    constexpr bool is_positional() const
+    {
+        return m_name.is_null();
+    }
 };
 
 template <typename T>
@@ -240,23 +294,112 @@ public:
     }
 };
 
-struct Value_Of_Type_Matcher
-    : Value_Matcher
-    , Value_Holder<Value> {
+struct Value_Matcher : virtual Was_Matched {
 private:
-    const Type* m_expected_type;
+    Type m_type;
+    static_assert(
+        std::is_trivially_copyable_v<Type>,
+        "This design needs to be reconsidered if Type is expensive to copy."
+    );
 
 public:
     [[nodiscard]]
-    explicit Value_Of_Type_Matcher(const Type* expected_type)
-        : m_expected_type { expected_type }
+    explicit Value_Matcher(const Type& type)
+        : Was_Matched {}
+        , m_type { type }
     {
-        COWEL_ASSERT(expected_type);
+        COWEL_DEBUG_ASSERT(type.is_canonical());
+    }
+
+    /// @brief Attempts matching the value contained in `argument`
+    /// according to this matcher's behavior.
+    /// @param argument The argument to match.
+    /// @param frame The frame index of the argument.
+    /// @param context The current context.
+    /// @return A `Processing_Status` if content generation failed during the matching process.
+    [[nodiscard]]
+    virtual Processing_Status match_value(
+        const Argument& argument,
+        Frame_Index frame,
+        Context& context,
+        const Match_Fail_Options& on_fail
+    ) = 0;
+
+    [[nodiscard]]
+    const Type& get_type() const
+    {
+        return m_type;
+    }
+};
+
+/// @brief Matches a lazy value of single specific kind.
+/// This is typically used for blocks and quoted strings.
+struct Lazy_Value_Of_Type_Matcher final
+    : Value_Matcher
+    , Value_Holder<Argument> {
+private:
+    Frame_Index m_markup_frame { -2 };
+
+public:
+    [[nodiscard]]
+    explicit Lazy_Value_Of_Type_Matcher(const Type& expected_type)
+        : Value_Matcher { expected_type }
+    {
     }
 
     [[nodiscard]]
     Processing_Status match_value(
-        const ast::Expression& argument,
+        const Argument& argument,
+        Frame_Index frame,
+        Context&,
+        const Match_Fail_Options& //
+    ) override;
+
+    [[nodiscard]]
+    Frame_Index get_frame() const
+    {
+        COWEL_ASSERT(was_matched());
+        return m_markup_frame;
+    }
+};
+
+struct Textual_Matcher : Value_Matcher {
+
+    [[nodiscard]]
+    explicit Textual_Matcher()
+        : Value_Matcher { Type::str }
+    {
+    }
+
+    [[nodiscard]]
+    Processing_Status match_value(
+        const Argument& argument,
+        Frame_Index frame,
+        Context& context,
+        const Match_Fail_Options& on_fail
+    ) override;
+
+    [[nodiscard]]
+    virtual bool match_string(
+        const Argument& argument,
+        std::u8string_view str,
+        Context& context,
+        Fail_Callback on_fail
+    ) = 0;
+};
+
+struct Value_Of_Type_Matcher
+    : Value_Matcher
+    , Value_Holder<Value> {
+    [[nodiscard]]
+    explicit Value_Of_Type_Matcher(const Type& expected_type)
+        : Value_Matcher { expected_type }
+    {
+    }
+
+    [[nodiscard]]
+    Processing_Status match_value(
+        const Argument& argument,
         Frame_Index frame,
         Context& context,
         const Match_Fail_Options& on_fail
@@ -272,14 +415,15 @@ private:
 
 public:
     [[nodiscard]]
-    explicit Spliceable_To_String_Matcher(std::pmr::memory_resource* memory)
-        : m_data { memory }
+    explicit Spliceable_To_String_Matcher(std::pmr::memory_resource* const memory)
+        : Value_Matcher { Type::any }
+        , m_data { memory }
     {
     }
 
     [[nodiscard]]
     Processing_Status match_value(
-        const ast::Expression& argument,
+        const Argument& argument,
         Frame_Index frame,
         Context& context,
         const Match_Fail_Options& on_fail
@@ -295,14 +439,15 @@ private:
 
 public:
     [[nodiscard]]
-    explicit String_Matcher(std::pmr::memory_resource* memory)
-        : m_data { memory }
+    explicit String_Matcher(std::pmr::memory_resource* const memory)
+        : Value_Matcher { Type::str }
+        , m_data { memory }
     {
     }
 
     [[nodiscard]]
     Processing_Status match_value(
-        const ast::Expression& argument,
+        const Argument& argument,
         Frame_Index frame,
         Context& context,
         const Match_Fail_Options& on_fail
@@ -322,11 +467,13 @@ struct Boolean_Matcher final
 
     [[nodiscard]]
     explicit Boolean_Matcher()
-        = default;
+        : Value_Matcher { Type::boolean }
+    {
+    }
 
     [[nodiscard]]
     Processing_Status match_value(
-        const ast::Expression& argument,
+        const Argument& argument,
         Frame_Index frame,
         Context&,
         const Match_Fail_Options& on_fail
@@ -339,11 +486,13 @@ struct Integer_Matcher final
 
     [[nodiscard]]
     explicit Integer_Matcher()
-        = default;
+        : Value_Matcher { Type::integer }
+    {
+    }
 
     [[nodiscard]]
     Processing_Status match_value(
-        const ast::Expression& argument,
+        const Argument& argument,
         Frame_Index frame,
         Context&,
         const Match_Fail_Options& on_fail
@@ -356,11 +505,13 @@ struct Float_Matcher final
 
     [[nodiscard]]
     explicit Float_Matcher()
-        = default;
+        : Value_Matcher { Type::floating }
+    {
+    }
 
     [[nodiscard]]
     Processing_Status match_value(
-        const ast::Expression& argument,
+        const Argument& argument,
         Frame_Index frame,
         Context&,
         const Match_Fail_Options& on_fail
@@ -384,7 +535,7 @@ public:
 
     [[nodiscard]]
     bool match_string(
-        const ast::Expression& argument,
+        const Argument& argument,
         std::u8string_view str,
         Context&,
         Fail_Callback on_fail
@@ -410,9 +561,213 @@ public:
     }
 };
 
-// GROUP MEMBER ====================================================================================
+struct Block_Matcher final
+    : Value_Matcher
+    , Value_Holder<Value> {
 
-struct Group_Member_Matcher {
+    [[nodiscard]]
+    explicit Block_Matcher()
+        : Value_Matcher { Type::block }
+    {
+    }
+
+    [[nodiscard]]
+    Processing_Status match_value(
+        const Argument& argument,
+        Frame_Index frame,
+        Context&,
+        const Match_Fail_Options& on_fail
+    ) override;
+};
+
+struct Pack_Of_Type_Matcher : Value_Matcher {
+public:
+    using value_type = Value_And_Location<Value>;
+
+private:
+    Small_Vector<value_type, 16> m_values;
+
+public:
+    [[nodiscard]]
+    explicit Pack_Of_Type_Matcher(const Type& type)
+        : Value_Matcher { type }
+    {
+        COWEL_ASSERT(type.is_pack());
+        COWEL_ASSERT(type.is_canonical());
+    }
+
+    [[nodiscard]]
+    Processing_Status match_value(
+        const Argument& argument,
+        Frame_Index frame,
+        Context& context,
+        const Match_Fail_Options& on_fail
+    ) override;
+
+    [[nodiscard]]
+    bool was_matched() const override
+    {
+        return !m_values.empty();
+    }
+
+    void reset() noexcept override
+    {
+        m_values.clear();
+    }
+
+    [[nodiscard]]
+    std::span<value_type> get()
+    {
+        return m_values;
+    }
+    [[nodiscard]]
+    std::span<const value_type> get() const
+    {
+        return m_values;
+    }
+};
+
+struct Pack_Lazy_Any_Matcher : Value_Matcher {
+public:
+    using value_type = Argument;
+
+private:
+    Small_Vector<value_type, 16> m_values;
+
+public:
+    [[nodiscard]]
+    explicit Pack_Lazy_Any_Matcher()
+        : Value_Matcher { Type::pack_of(&Type::any) }
+    {
+    }
+
+    [[nodiscard]]
+    Processing_Status match_value(
+        const Argument& argument, //
+        Frame_Index,
+        Context&,
+        const Match_Fail_Options&
+    ) override
+    {
+        m_values.push_back(argument);
+        return Processing_Status::ok;
+    }
+
+    [[nodiscard]]
+    bool was_matched() const override
+    {
+        return !m_values.empty();
+    }
+
+    void reset() noexcept override
+    {
+        m_values.clear();
+    }
+
+    [[nodiscard]]
+    std::span<const value_type> get() const
+    {
+        return m_values;
+    }
+};
+
+struct Pack_Named_Of_Type_Matcher : Value_Matcher {
+    using value_type = Group_Member_Value;
+
+private:
+    Small_Vector<value_type, 16> m_values;
+    Small_Vector<File_Source_Span, 16> m_locations;
+
+protected:
+    const Type& m_element_type;
+
+public:
+    [[nodiscard]]
+    explicit Pack_Named_Of_Type_Matcher(const Type& pack_named_type)
+        : Value_Matcher { pack_named_type }
+        , m_element_type { pack_named_type.get_members().front().get_members().front() }
+    {
+        COWEL_ASSERT(pack_named_type.is_pack());
+        COWEL_ASSERT(pack_named_type.get_members().front().is_named());
+        COWEL_DEBUG_ASSERT(pack_named_type.is_canonical());
+    }
+
+    [[nodiscard]]
+    Processing_Status match_value(
+        const Argument& argument,
+        Frame_Index frame,
+        Context& context,
+        const Match_Fail_Options& on_fail
+    ) override;
+
+    [[nodiscard]]
+    bool was_matched() const override
+    {
+        return !m_values.empty();
+    }
+
+    void reset() noexcept override
+    {
+        m_values.clear();
+    }
+
+    [[nodiscard]]
+    std::span<const value_type> get() const
+    {
+        return m_values;
+    }
+
+    [[nodiscard]]
+    std::span<const File_Source_Span> get_locations() const
+    {
+        return m_locations;
+    }
+
+    [[nodiscard]]
+    const Type& get_element_type() const
+    {
+        return m_element_type;
+    }
+};
+
+namespace detail {
+
+inline constexpr auto named_str = Type::named(&Type::str);
+inline constexpr auto pack_named_str = Type::pack_of(&named_str);
+inline constexpr auto group_pack_named_str = Type::group_of({ &pack_named_str, 1 });
+
+} // namespace detail
+
+struct Pack_Named_Str_Matcher final : Pack_Named_Of_Type_Matcher {
+
+    [[nodiscard]]
+    explicit Pack_Named_Str_Matcher()
+        : Pack_Named_Of_Type_Matcher { detail::pack_named_str }
+    {
+    }
+};
+
+struct Group_Pack_Named_Str_Matcher final
+    : Value_Matcher
+    , Value_Holder<Value> {
+    using value_type = const ast::Group_Member*;
+
+    [[nodiscard]]
+    explicit Group_Pack_Named_Str_Matcher()
+        : Value_Matcher { detail::group_pack_named_str }
+    {
+    }
+
+    [[nodiscard]]
+    Processing_Status match_value(
+        const Argument& argument,
+        Frame_Index frame,
+        Context& context,
+        const Match_Fail_Options& on_fail
+    ) override;
+};
+
+struct Parameter {
 private:
     std::u8string_view m_name;
     Optionality m_optionality;
@@ -420,7 +775,7 @@ private:
 
 public:
     [[nodiscard]]
-    constexpr explicit Group_Member_Matcher(
+    constexpr explicit Parameter(
         std::u8string_view name,
         Optionality optionality,
         Value_Matcher& value_matcher
@@ -460,394 +815,33 @@ public:
     {
         return m_value_matcher;
     }
-};
-
-// PACK ============================================================================================
-
-struct Pack_Matcher {
-public:
-    [[nodiscard]]
-    explicit Pack_Matcher()
-        = default;
 
     [[nodiscard]]
-    virtual Processing_Status match_pack(
-        std::span<const ast::Group_Member> members,
-        Frame_Index frame,
-        Context& context,
-        const Match_Fail_Options& on_fail
-    ) = 0;
-};
-
-struct Pack_Usual_Matcher final : Pack_Matcher {
-private:
-    std::span<Group_Member_Matcher* const> m_member_matchers;
-
-public:
-    [[nodiscard]]
-    explicit Pack_Usual_Matcher(std::span<Group_Member_Matcher* const> member_matchers)
-        : m_member_matchers { member_matchers }
+    const Type& get_type() const
     {
-        if constexpr (is_debug_build) {
-            for (const auto* const matcher : member_matchers) {
-                COWEL_ASSERT(matcher != nullptr);
-            }
-        }
+        return m_value_matcher.get_type();
     }
-
-    [[nodiscard]]
-    Processing_Status match_pack(
-        std::span<const ast::Group_Member> members,
-        Frame_Index frame,
-        Context& context,
-        const Match_Fail_Options& on_fail
-    ) override;
-
-private:
-    [[nodiscard]]
-    Processing_Status do_match(
-        std::span<const ast::Group_Member> members,
-        Frame_Index frame,
-        Context& context,
-        const Match_Fail_Options& on_fail,
-        std::span<int> argument_indices_by_parameter,
-        std::size_t cumulative_arg_index
-    );
-};
-
-struct Empty_Pack_Matcher final : Pack_Matcher {
-public:
-    [[nodiscard]]
-    explicit Empty_Pack_Matcher()
-        = default;
-
-    [[nodiscard]]
-    Processing_Status match_pack(
-        std::span<const ast::Group_Member> members,
-        Frame_Index frame,
-        Context& context,
-        const Match_Fail_Options& on_fail
-    ) override;
-};
-
-// GROUP ===========================================================================================
-
-struct Group_Matcher : Value_Matcher {
-    [[nodiscard]]
-    explicit Group_Matcher()
-        = default;
-
-    [[nodiscard]]
-    Processing_Status match_value(
-        const ast::Expression& argument,
-        Frame_Index frame,
-        Context& context,
-        const Match_Fail_Options& on_fail
-    ) override;
-
-    /// @brief Matches a group.
-    /// @param group The group, or a null pointer in the event of an artificial empty group
-    /// such as the one in a directive invocation with no group.
-    [[nodiscard]]
-    virtual Processing_Status match_group(
-        const ast::Primary* group,
-        Frame_Index frame,
-        Context& context,
-        const Match_Fail_Options& on_fail
-    ) = 0;
-};
-
-struct Group_Pack_Lazy_Any_Matcher final : Group_Matcher {
-private:
-    const ast::Primary* m_group = nullptr;
-    Frame_Index m_group_frame;
-
-public:
-    [[nodiscard]]
-    explicit Group_Pack_Lazy_Any_Matcher()
-        = default;
-
-    [[nodiscard]]
-    bool was_matched() const override
-    {
-        return m_group != nullptr;
-    }
-
-    void reset() noexcept override
-    {
-        m_group = nullptr;
-    }
-
-    [[nodiscard]]
-    const ast::Primary& get() const
-    {
-        COWEL_ASSERT(was_matched());
-        return *m_group;
-    }
-
-    [[nodiscard]]
-    Frame_Index get_frame() const
-    {
-        COWEL_ASSERT(was_matched());
-        return m_group_frame;
-    }
-
-    [[nodiscard]]
-    Processing_Status match_group(
-        const ast::Primary* group,
-        Frame_Index frame,
-        Context&,
-        const Match_Fail_Options& //
-    ) override
-    {
-        COWEL_ASSERT(!group || group->get_kind() == ast::Primary_Kind::group);
-
-        m_group = group;
-        m_group_frame = frame;
-        return Processing_Status::ok;
-    }
-};
-
-struct Group_Pack_Named_Lazy_Any_Matcher : Group_Matcher {
-    using Filter = bool(const ast::Group_Member&);
-
-private:
-    const ast::Primary* m_group = nullptr;
-    Frame_Index m_group_frame;
-    Filter* m_filter = nullptr;
-
-public:
-    [[nodiscard]]
-    explicit Group_Pack_Named_Lazy_Any_Matcher()
-        = default;
-
-    [[nodiscard]]
-    explicit Group_Pack_Named_Lazy_Any_Matcher(Filter* filter) noexcept
-        : m_filter { filter }
-    {
-    }
-
-    [[nodiscard]]
-    bool was_matched() const override
-    {
-        return m_group != nullptr;
-    }
-
-    void reset() noexcept override
-    {
-        m_group = nullptr;
-    }
-
-    [[nodiscard]]
-    const ast::Primary& get() const
-    {
-        COWEL_ASSERT(m_group);
-        return *m_group;
-    }
-
-    [[nodiscard]]
-    Frame_Index get_frame() const
-    {
-        COWEL_ASSERT(was_matched());
-        return m_group_frame;
-    }
-
-    [[nodiscard]]
-    Processing_Status match_group(
-        const ast::Primary* group,
-        Frame_Index frame,
-        Context& context,
-        const Match_Fail_Options& on_fail
-    ) override
-    {
-        COWEL_ASSERT(!group || group->get_kind() == ast::Primary_Kind::group);
-
-        m_group = group;
-        m_group_frame = frame;
-
-        if (!group) {
-            return Processing_Status::ok;
-        }
-        return match_pack(group->get_members(), frame, context, on_fail);
-    }
-
-private:
-    [[nodiscard]]
-    Processing_Status match_pack(
-        std::span<const ast::Group_Member> members,
-        Frame_Index frame,
-        Context& context,
-        const Match_Fail_Options& on_fail
-    );
 };
 
 [[nodiscard]]
-inline bool is_html_attribute_convertible(const ast::Group_Member& member)
+Processing_Status match_call(
+    std::span<Parameter* const> parameters,
+    const Invocation& call,
+    Context& context,
+    Fail_Callback on_fail = make_fail_callback(),
+    Processing_Status on_fail_status = Processing_Status::error
+);
+
+[[nodiscard]]
+inline Processing_Status match_call_fatal_error(
+    const std::span<Parameter* const> parameters,
+    const Invocation& call,
+    Context& context,
+    const Fail_Callback on_fail = make_fail_callback<Severity::fatal>()
+)
 {
-    return member.get_kind() == ast::Member_Kind::named //
-        && member.has_value() //
-        && member.get_value().is_spliceable();
+    return match_call(parameters, call, context, on_fail, Processing_Status::fatal);
 }
-
-/// @brief A `Group_Pack_Named_Lazy_Any_Matcher` which uses
-/// `is_html_attribute_convertible` as a filter.
-struct Group_Pack_Named_Lazy_Spliceable_Matcher : Group_Pack_Named_Lazy_Any_Matcher {
-    [[nodiscard]]
-    explicit Group_Pack_Named_Lazy_Spliceable_Matcher() noexcept
-        : Group_Pack_Named_Lazy_Any_Matcher(&is_html_attribute_convertible)
-    {
-    }
-};
-
-struct Group_Pack_Value_Matcher : Group_Matcher {
-private:
-    bool m_matched = false;
-    std::pmr::vector<Value_And_Location<Value>> m_values;
-
-public:
-    [[nodiscard]]
-    explicit Group_Pack_Value_Matcher(std::pmr::memory_resource* memory)
-        : m_values { memory }
-    {
-    }
-
-    [[nodiscard]]
-    bool was_matched() const override
-    {
-        return m_matched;
-    }
-
-    void reset() noexcept override
-    {
-        m_matched = false;
-    }
-
-    [[nodiscard]]
-    std::span<const Value_And_Location<Value>> get_values() const
-    {
-        COWEL_ASSERT(m_matched);
-        return m_values;
-    }
-
-    [[nodiscard]]
-    Processing_Status match_group(
-        const ast::Primary* group,
-        Frame_Index frame,
-        Context& context,
-        const Match_Fail_Options& on_fail
-    ) override
-    {
-        COWEL_ASSERT(!group || group->get_kind() == ast::Primary_Kind::group);
-        COWEL_DEBUG_ASSERT(status_is_error(on_fail.status));
-
-        const auto members = [&] -> std::span<const ast::Group_Member> {
-            if (group) {
-                return group->get_members();
-            }
-            return {};
-        }();
-        const Processing_Status result = match_pack(members, frame, context, on_fail);
-        if (result == Processing_Status::ok) {
-            m_matched = true;
-        }
-        return result;
-    }
-
-private:
-    [[nodiscard]]
-    Processing_Status match_pack(
-        std::span<const ast::Group_Member> members,
-        Frame_Index frame,
-        Context& context,
-        const Match_Fail_Options& on_fail
-    );
-};
-
-struct Group_Pack_Matcher final : Group_Matcher {
-private:
-    Pack_Matcher& m_pack_matcher;
-    const ast::Primary* m_group = nullptr;
-
-public:
-    [[nodiscard]]
-    explicit Group_Pack_Matcher(Pack_Matcher& pack_matcher)
-        : m_pack_matcher { pack_matcher }
-    {
-    }
-
-    [[nodiscard]]
-    bool was_matched() const override
-    {
-        return m_group != nullptr;
-    }
-
-    void reset() noexcept override
-    {
-        m_group = nullptr;
-    }
-
-    [[nodiscard]]
-    Processing_Status match_group(
-        const ast::Primary* group,
-        Frame_Index frame,
-        Context& context,
-        const Match_Fail_Options& on_fail
-    ) override
-    {
-        const auto members = [&] -> std::span<const ast::Group_Member> {
-            if (group) {
-                return group->get_members();
-            }
-            return {};
-        }();
-        return m_pack_matcher.match_pack(members, frame, context, on_fail);
-    }
-};
-
-// CALL ============================================================================================
-
-struct Call_Matcher {
-private:
-    Group_Matcher& m_group_matcher;
-
-public:
-    [[nodiscard]]
-    explicit Call_Matcher(Group_Matcher& args)
-        : m_group_matcher { args }
-    {
-    }
-
-    [[nodiscard]]
-    Processing_Status match_call(
-        const Invocation& call,
-        Context& context,
-        Fail_Callback on_fail,
-        Processing_Status on_fail_status = Processing_Status::error
-    )
-    {
-        return match_group(
-            call.arguments, call.content_frame, context,
-            Match_Fail_Options {
-                .emit = on_fail,
-                .status = on_fail_status,
-                .location = call.get_arguments_source_span(),
-            }
-        );
-    }
-
-private:
-    [[nodiscard]]
-    Processing_Status match_group(
-        const ast::Primary* group,
-        Frame_Index frame,
-        Context& context,
-        const Match_Fail_Options& on_fail
-    )
-    {
-        COWEL_ASSERT(!group || group->get_kind() == ast::Primary_Kind::group);
-        return m_group_matcher.match_group(group, frame, context, on_fail);
-    }
-};
 
 } // namespace cowel
 

--- a/include/cowel/type.hpp
+++ b/include/cowel/type.hpp
@@ -356,6 +356,26 @@ public:
     {
         return m_kind;
     }
+    [[nodiscard]]
+    constexpr bool is_pack() const
+    {
+        return m_kind == Type_Kind::pack;
+    }
+    [[nodiscard]]
+    constexpr bool is_group() const
+    {
+        return m_kind == Type_Kind::group;
+    }
+    [[nodiscard]]
+    constexpr bool is_named() const
+    {
+        return m_kind == Type_Kind::named;
+    }
+    [[nodiscard]]
+    constexpr bool is_lazy() const
+    {
+        return m_kind == Type_Kind::lazy;
+    }
 
     [[nodiscard]]
     friend constexpr bool operator==(const Type& x, const Type& y)

--- a/include/cowel/util/small_vector.hpp
+++ b/include/cowel/util/small_vector.hpp
@@ -78,6 +78,23 @@ public:
     }
 
     [[nodiscard]]
+    constexpr explicit Small_Vector(const std::size_t amount, const Alloc& alloc = {})
+        : m_alloc { alloc }
+    {
+        resize(amount);
+    }
+    [[nodiscard]]
+    constexpr explicit Small_Vector(
+        const std::size_t amount,
+        const T& value,
+        const Alloc& alloc = {}
+    )
+        : m_alloc { alloc }
+    {
+        resize(amount, value);
+    }
+
+    [[nodiscard]]
     constexpr Small_Vector(std::initializer_list<T> list, const Alloc& alloc = {})
         : m_alloc { alloc }
     {
@@ -190,13 +207,14 @@ public:
 
     [[nodiscard]]
     friend constexpr bool operator==(const Small_Vector& x, const Small_Vector& y)
+        requires std::equality_comparable<T>
     {
         return x.m_size == y.m_size && std::ranges::equal(x, y);
     }
 
     [[nodiscard]]
     friend constexpr auto operator<=>(const Small_Vector& x, const Small_Vector& y)
-        -> decltype(x.front() <=> y.front())
+        requires std::three_way_comparable<T>
     {
         return std::lexicographical_compare_three_way(x.begin(), x.end(), y.begin(), y.end());
     }
@@ -216,6 +234,33 @@ public:
             return;
         }
         grow_to(amount);
+    }
+
+    constexpr void resize(const std::size_t amount, const T& value = {})
+    {
+        if (amount < m_size) {
+            if (amount == 0) {
+                clear();
+            }
+            else if (m_using_small) {
+                std::ranges::fill(m_small_data + amount, m_small_data + m_size, T {});
+            }
+            else {
+                std::ranges::destroy(m_dynamic_data + amount, m_dynamic_data + m_size);
+            }
+        }
+        else if (amount > m_size) {
+            if (m_using_small && amount <= small_cap) {
+                std::ranges::fill(m_small_data + m_size, m_small_data + amount, value);
+            }
+            else {
+                ensure_dynamic_storage(amount);
+                std::ranges::uninitialized_fill(
+                    m_dynamic_data + m_size, m_dynamic_data + amount, value
+                );
+            }
+        }
+        m_size = amount;
     }
 
     constexpr void swap(Small_Vector& other) noexcept(std::is_nothrow_move_constructible_v<T>)

--- a/include/cowel/util/source_position.hpp
+++ b/include/cowel/util/source_position.hpp
@@ -136,6 +136,14 @@ struct Basic_File_Source_Span : Source_Span {
     File file;
 
     [[nodiscard]]
+    constexpr Basic_File_Source_Span()
+        requires std::is_default_constructible_v<File>
+        : Source_Span {}
+        , file {}
+    {
+    }
+
+    [[nodiscard]]
     constexpr Basic_File_Source_Span(const Source_Span& local, File file)
         : Source_Span { local }
         , file { file }

--- a/include/cowel/value.hpp
+++ b/include/cowel/value.hpp
@@ -206,6 +206,12 @@ private:
 
 public:
     [[nodiscard]]
+    constexpr Value() noexcept
+        : Value { Value::null }
+    {
+    }
+
+    [[nodiscard]]
     constexpr Value(const Value& other) noexcept
         : Value {
             other.m_value,
@@ -466,20 +472,9 @@ public:
     }
 
     [[nodiscard]]
-    // NOLINTNEXTLINE(readability-make-member-function-const)
-    std::span<Group_Member_Value> get_group_members()
-    {
-        // The linter suppression is necessary because of a clang-tidy bug:
-        // https://github.com/llvm/llvm-project/issues/174269
-        COWEL_ASSERT(get_type_kind() == Type_Kind::group);
-        return m_value.group.as_span();
-    }
+    std::span<Group_Member_Value> get_group_members();
     [[nodiscard]]
-    std::span<const Group_Member_Value> get_group_members() const
-    {
-        COWEL_ASSERT(get_type_kind() == Type_Kind::group);
-        return m_value.group.as_span();
-    }
+    std::span<const Group_Member_Value> get_group_members() const;
 
     // TODO: There is currently no efficient way to move strings out of a Value.
     //       Maybe an rvalue reference overload for the functions above would make sense.
@@ -498,6 +493,20 @@ struct Group_Member_Value {
     /// @brief The value of the group member.
     Value value;
 };
+
+// NOLINTNEXTLINE(readability-make-member-function-const)
+inline std::span<Group_Member_Value> Value::get_group_members()
+{
+    // The linter suppression is necessary because of a clang-tidy bug:
+    // https://github.com/llvm/llvm-project/issues/174269
+    COWEL_ASSERT(get_type_kind() == Type_Kind::group);
+    return m_value.group.as_span();
+}
+inline std::span<const Group_Member_Value> Value::get_group_members() const
+{
+    COWEL_ASSERT(get_type_kind() == Type_Kind::group);
+    return m_value.group.as_span();
+}
 
 template <class T>
 constexpr Value::Value(

--- a/src/main/cpp/build_ast.cpp
+++ b/src/main/cpp/build_ast.cpp
@@ -187,7 +187,7 @@ Group_Member Group_Member::named(Primary&& name, Expression&& value)
     return {
         value.get_source_span(),
         value.get_source(),
-        gc_ref_make<Primary>( std::move(name)),
+        gc_ref_make<Primary>(std::move(name)),
         gc_ref_make<Expression>(std::move(value)),
         Member_Kind::named,
     };

--- a/src/main/cpp/build_ast.cpp
+++ b/src/main/cpp/build_ast.cpp
@@ -187,8 +187,8 @@ Group_Member Group_Member::named(Primary&& name, Expression&& value)
     return {
         value.get_source_span(),
         value.get_source(),
-        std::move(name),
-        std::move(value),
+        gc_ref_make<Primary>( std::move(name)),
+        gc_ref_make<Expression>(std::move(value)),
         Member_Kind::named,
     };
     // clang-format on
@@ -203,7 +203,7 @@ Group_Member Group_Member::positional(Expression&& value)
         source_span,
         value.get_source(),
         {},
-        std::move(value),
+        gc_ref_make<Expression>(std::move(value)),
         Member_Kind::positional,
     };
     // clang-format on
@@ -212,8 +212,8 @@ Group_Member Group_Member::positional(Expression&& value)
 Group_Member::Group_Member(
     const File_Source_Span& source_span,
     std::u8string_view source,
-    std::optional<Primary>&& name,
-    std::optional<Expression>&& value,
+    GC_Ref<Primary> name,
+    GC_Ref<Expression> value,
     Member_Kind type
 )
     : m_source_span { source_span }

--- a/src/main/cpp/builtin_directive_set.cpp
+++ b/src/main/cpp/builtin_directive_set.cpp
@@ -351,8 +351,6 @@ constexpr There_Behavior there //
     {};
 constexpr Fixed_Name_Passthrough_Behavior tr //
     { HTML_Tag_Name(u8"tr"), Policy_Usage::html, Directive_Display::block };
-constexpr Trim_Behavior trim //
-    { Directive_Display::in_line };
 constexpr Fixed_Name_Passthrough_Behavior tt //
     { HTML_Tag_Name(u8"tt-"), Policy_Usage::inherit, Directive_Display::in_line };
 constexpr Fixed_Name_Passthrough_Behavior u //
@@ -551,7 +549,6 @@ constexpr Name_And_Behavior behaviors_by_name[] {
     COWEL_NAME_AND_BEHAVIOR_ENTRY(thead),
     COWEL_NAME_AND_BEHAVIOR_ENTRY(there),
     COWEL_NAME_AND_BEHAVIOR_ENTRY(tr),
-    COWEL_NAME_AND_BEHAVIOR_ENTRY(trim),
     COWEL_NAME_AND_BEHAVIOR_ENTRY(tt),
     COWEL_NAME_AND_BEHAVIOR_ENTRY(u),
     COWEL_NAME_AND_BEHAVIOR_ENTRY(ul),

--- a/src/main/cpp/directive_processing.cpp
+++ b/src/main/cpp/directive_processing.cpp
@@ -917,58 +917,6 @@ void diagnose(
     }
 }
 
-Processing_Status named_arguments_to_attributes(
-    Text_Buffer_Attribute_Writer& out,
-    std::span<const ast::Group_Member> arguments,
-    Frame_Index frame,
-    Context& context,
-    Attribute_Style style
-)
-{
-    return process_greedy(arguments, [&](const ast::Group_Member& a) -> Processing_Status {
-        if (a.get_kind() == ast::Member_Kind::ellipsis) {
-            const Stack_Frame& ellipsis_frame = context.get_call_stack()[frame];
-            return named_arguments_to_attributes(
-                out, ellipsis_frame.invocation.get_arguments_span(),
-                ellipsis_frame.invocation.content_frame, context, style
-            );
-        }
-        COWEL_ASSERT(a.get_kind() == ast::Member_Kind::named);
-        return named_argument_to_attribute(out, a, frame, context, style);
-    });
-}
-
-Processing_Status named_argument_to_attribute(
-    Text_Buffer_Attribute_Writer& out,
-    const ast::Group_Member& a,
-    Frame_Index frame,
-    Context& context,
-    Attribute_Style style
-)
-{
-    COWEL_ASSERT(a.get_kind() == ast::Member_Kind::named);
-
-    const Result<Value, Processing_Status> name = evaluate(a.get_name(), frame, context);
-    if (!name) {
-        return name.error();
-    }
-    const Result<Value, Processing_Status> value
-        = evaluate_expression(a.get_value(), frame, context);
-    if (!value) {
-        return name.error();
-    }
-    const Result<Value, Processing_Status> value_string
-        = splice_value_to_string(*value, a.get_value_span(), context);
-    if (!value_string) {
-        return value_string.error();
-    }
-
-    // TODO: this is simply going to crash if the attribute name is not valid;
-    // investigate whether this needs work, and possibly leave a comment here if it's okay
-    out.write_attribute(HTML_Attribute_Name(name->as_string()), value_string->as_string(), style);
-    return Processing_Status::ok;
-}
-
 Result<void, std::size_t> named_str_arguments_to_attributes(
     Text_Buffer_Attribute_Writer& out,
     const std::span<const Group_Member_Value> arguments,
@@ -1050,7 +998,6 @@ Processing_Status named_arguments_to_attributes_or_error(
     const bool are_arguments_strings = matcher.get_element_type() == Type::str
         || std::ranges::all_of(matcher.get(),
                                [](const Group_Member_Value& val) { return val.value.is_str(); });
-
     if (are_arguments_strings) {
         return do_named_arguments_to_attributes_or_error(matcher.get());
     }
@@ -1060,6 +1007,9 @@ Processing_Status named_arguments_to_attributes_or_error(
         const auto& [name, value] = matcher.get()[i];
         Result<Value, Processing_Status> spliced
             = splice_value_to_string(value, matcher.get_locations()[i], context);
+        if (!spliced) {
+            return spliced.error();
+        }
         string_values.push_back({ .name = name, .value = std::move(*spliced) });
     }
     return do_named_arguments_to_attributes_or_error(string_values);

--- a/src/main/cpp/directive_processing.cpp
+++ b/src/main/cpp/directive_processing.cpp
@@ -274,64 +274,6 @@ void try_lookup_error(const ast::Directive& directive, Context& context)
 
 } // namespace
 
-Processing_Status splice_all_trimmed(
-    Content_Policy& out,
-    std::span<const ast::Markup_Element> content,
-    Frame_Index frame,
-    Context& context
-)
-{
-    content = trim_blank_text(content);
-
-    struct Visitor {
-        Content_Policy& out;
-        Context& context;
-        std::size_t i;
-        std::size_t size;
-        Frame_Index frame;
-
-        void write_trimmed(std::u8string_view str) const
-        {
-            // Note that the following two conditions are not mutually exclusive
-            // when content contains just one element.
-            if (i == 0) {
-                str = trim_ascii_blank_left(str);
-            }
-            if (i + 1 == size) {
-                str = trim_ascii_blank_right(str);
-            }
-            // The trimming above should have gotten rid of entirely empty strings.
-            COWEL_ASSERT(!str.empty());
-            out.write(str, Output_Language::text);
-        }
-
-        [[nodiscard]]
-        Processing_Status operator()(const ast::Primary& node) const
-        {
-            if (node.get_kind() != ast::Primary_Kind::text) {
-                return out.consume(node, frame, context);
-            }
-            write_trimmed(node.get_source());
-            return Processing_Status::ok;
-        }
-
-        [[nodiscard]]
-        Processing_Status operator()(const ast::Directive& e) const
-        {
-            return out.consume(e, frame, context);
-        }
-    };
-
-    return process_greedy(
-        content,
-        [&, i = 0uz](const ast::Markup_Element& c) mutable -> Processing_Status {
-            const auto result = std::visit(Visitor { out, context, i, content.size(), frame }, c);
-            ++i;
-            return result;
-        }
-    );
-}
-
 Processing_Status splice_to_plaintext(
     std::pmr::vector<char8_t>& out,
     std::span<const ast::Markup_Element> content,
@@ -583,8 +525,6 @@ Processing_Status splice_expression_to_plaintext(
     Context& context
 )
 {
-    COWEL_DEBUG_ASSERT(value.is_spliceable_value());
-
     Capturing_Ref_Text_Sink sink { out, Output_Language::text };
     Text_Only_Policy policy { sink };
     return splice_expression(policy, value, frame, context);
@@ -916,20 +856,6 @@ Processing_Status splice_directive_invocation( //
     );
 }
 
-Processing_Status
-match_empty_arguments(const Invocation& call, Context& context, Processing_Status fail_status)
-{
-    Empty_Pack_Matcher args_matcher;
-    Group_Pack_Matcher group_matcher { args_matcher };
-    Call_Matcher call_matcher { group_matcher };
-
-    const auto fail_callback = fail_status == Processing_Status::fatal
-        ? make_fail_callback<Severity::fatal>()
-        : make_fail_callback<Severity::error>();
-
-    return call_matcher.match_call(call, context, fail_callback, fail_status);
-}
-
 void diagnose(
     Syntax_Highlight_Error error,
     std::u8string_view lang,
@@ -1041,6 +967,102 @@ Processing_Status named_argument_to_attribute(
     // investigate whether this needs work, and possibly leave a comment here if it's okay
     out.write_attribute(HTML_Attribute_Name(name->as_string()), value_string->as_string(), style);
     return Processing_Status::ok;
+}
+
+Result<void, std::size_t> named_str_arguments_to_attributes(
+    Text_Buffer_Attribute_Writer& out,
+    const std::span<const Group_Member_Value> arguments,
+    const Attribute_Style style
+)
+{
+    for (std::size_t i = 0; i < arguments.size(); ++i) {
+        const auto& [key, value] = arguments[i];
+        COWEL_ASSERT(key.is_str());
+        COWEL_ASSERT(value.is_str());
+        const std::u8string_view key_string = key.as_string();
+        if (!is_html_attribute_name(key_string)) {
+            return i;
+        }
+        out.write_attribute(HTML_Attribute_Name(key_string), value.as_string(), style);
+    }
+    return {};
+}
+
+Processing_Status named_arguments_to_attributes_or_error(
+    Text_Buffer_Attribute_Writer& out,
+    const Group_Pack_Named_Str_Matcher& matcher,
+    Context& context,
+    Attribute_Style style
+)
+{
+    if (!matcher.was_matched()) {
+        return Processing_Status::ok;
+    }
+    const Result<void, std::size_t> result
+        = named_str_arguments_to_attributes(out, matcher.get().get_group_members(), style);
+    if (result) {
+        return Processing_Status::ok;
+    }
+    context.try_error(
+        diagnostic::html_attribute, matcher.get_location(),
+        joined_char_sequence(
+            {
+                u8"The key \""sv,
+                matcher.get().get_group_members()[result.error()].name.as_string(),
+                u8"\" is not a valid HTML attribute name."sv,
+            }
+        )
+    );
+    return Processing_Status::error;
+}
+
+Processing_Status named_arguments_to_attributes_or_error(
+    Text_Buffer_Attribute_Writer& out,
+    const Pack_Named_Of_Type_Matcher& matcher,
+    Context& context,
+    Attribute_Style style
+)
+{
+    if (!matcher.was_matched()) {
+        return Processing_Status::ok;
+    }
+
+    const auto do_named_arguments_to_attributes_or_error
+        = [&](std::span<const Group_Member_Value> arguments) -> Processing_Status {
+        const Result<void, std::size_t> result
+            = named_str_arguments_to_attributes(out, arguments, style);
+        if (result) {
+            return Processing_Status::ok;
+        }
+        context.try_error(
+            diagnostic::html_attribute, matcher.get_locations()[result.error()],
+            joined_char_sequence(
+                {
+                    u8"The key \""sv,
+                    matcher.get()[result.error()].name.as_string(),
+                    u8"\" is not a valid HTML attribute name."sv,
+                }
+            )
+        );
+        return Processing_Status::error;
+    };
+
+    const bool are_arguments_strings = matcher.get_element_type() == Type::str
+        || std::ranges::all_of(matcher.get(),
+                               [](const Group_Member_Value& val) { return val.value.is_str(); });
+
+    if (are_arguments_strings) {
+        return do_named_arguments_to_attributes_or_error(matcher.get());
+    }
+
+    Small_Vector<Group_Member_Value, 8> string_values;
+    for (std::size_t i = 0; i < matcher.get().size(); ++i) {
+        const auto& [name, value] = matcher.get()[i];
+        Result<Value, Processing_Status> spliced
+            = splice_value_to_string(value, matcher.get_locations()[i], context);
+        string_values.push_back({ .name = name, .value = std::move(*spliced) });
+    }
+    return do_named_arguments_to_attributes_or_error(string_values);
 }
 
 Processing_Status try_generate_error(

--- a/src/main/cpp/directives/alias.cpp
+++ b/src/main/cpp/directives/alias.cpp
@@ -9,11 +9,13 @@ namespace cowel {
 
 Processing_Status Alias_Behavior::do_evaluate(const Invocation& call, Context& context) const
 {
-    Group_Pack_Value_Matcher strings { context.get_transient_memory() };
-    Call_Matcher call_matcher { strings };
+    Pack_Of_Type_Matcher names { Type::pack_of(&Type::str) };
+    Parameter names_param { u8"names"sv, Optionality::optional, names };
+    Block_Matcher content_matcher;
+    Parameter content_param { u8"content"sv, Optionality::mandatory, content_matcher };
+    Parameter* const parameters[] { &names_param, &content_param };
 
-    const Processing_Status match_status
-        = call_matcher.match_call(call, context, make_fail_callback(), Processing_Status::fatal);
+    const Processing_Status match_status = match_call_fatal_error(parameters, call, context);
     switch (match_status) {
     case Processing_Status::ok: break;
     case Processing_Status::brk:
@@ -29,7 +31,7 @@ Processing_Status Alias_Behavior::do_evaluate(const Invocation& call, Context& c
     }
     }
 
-    for (const auto& [alias_name, location] : strings.get_values()) {
+    for (const auto& [alias_name, location] : names.get()) {
         if (!alias_name.is_str()) {
             context.try_error(
                 diagnostic::type_mismatch, location,
@@ -47,9 +49,10 @@ Processing_Status Alias_Behavior::do_evaluate(const Invocation& call, Context& c
         }
     }
 
+    const Value& content = content_matcher.get();
     std::pmr::vector<char8_t> target_text { context.get_transient_memory() };
     const Processing_Status target_status
-        = splice_to_plaintext(target_text, call.get_content_span(), call.content_frame, context);
+        = splice_value_to_plaintext(target_text, content, content_matcher.get_location(), context);
     switch (target_status) {
     case Processing_Status::ok: break;
     case Processing_Status::brk:
@@ -103,7 +106,7 @@ Processing_Status Alias_Behavior::do_evaluate(const Invocation& call, Context& c
         return Processing_Status::fatal;
     }
 
-    for (const auto& [alias_name_value, location] : strings.get_values()) {
+    for (const auto& [alias_name_value, location] : names.get()) {
         const std::u8string_view alias_name = alias_name_value.as_string();
         if (alias_name.empty()) {
             context.try_fatal(

--- a/src/main/cpp/directives/bibliography.cpp
+++ b/src/main/cpp/directives/bibliography.cpp
@@ -132,32 +132,25 @@ Bibliography_Add_Behavior::splice(Content_Policy&, const Invocation& call, Conte
     auto* memory = context.get_transient_memory();
 
     Spliceable_To_String_Matcher id_string { memory };
-    Group_Member_Matcher id_member { u8"id", Optionality::mandatory, id_string };
+    Parameter id_param { u8"id", Optionality::mandatory, id_string };
     Spliceable_To_String_Matcher title_string { memory };
-    Group_Member_Matcher title_member { u8"title", Optionality::optional, title_string };
+    Parameter title_param { u8"title", Optionality::optional, title_string };
     Spliceable_To_String_Matcher date_string { memory };
-    Group_Member_Matcher date_member { u8"date", Optionality::optional, date_string };
+    Parameter date_param { u8"date", Optionality::optional, date_string };
     Spliceable_To_String_Matcher publisher_string { memory };
-    Group_Member_Matcher publisher_member { u8"publisher", Optionality::optional,
-                                            publisher_string };
+    Parameter publisher_param { u8"publisher", Optionality::optional, publisher_string };
     Spliceable_To_String_Matcher link_string { memory };
-    Group_Member_Matcher link_member { u8"link", Optionality::optional, link_string };
+    Parameter link_param { u8"link", Optionality::optional, link_string };
     Spliceable_To_String_Matcher long_link_string { memory };
-    Group_Member_Matcher long_link_member { u8"long-link", Optionality::optional,
-                                            long_link_string };
+    Parameter long_link_param { u8"long-link", Optionality::optional, long_link_string };
     Spliceable_To_String_Matcher author_string { memory };
-    Group_Member_Matcher author_member { u8"author", Optionality::optional, author_string };
-
-    Group_Member_Matcher* const matchers[] {
-        &id_member,   &title_member,     &date_member,   &publisher_member,
-        &link_member, &long_link_member, &author_member,
+    Parameter author_param { u8"author", Optionality::optional, author_string };
+    Parameter* const parameters[] {
+        &id_param,   &title_param,     &date_param,   &publisher_param,
+        &link_param, &long_link_param, &author_param,
     };
-    Pack_Usual_Matcher args_matcher { matchers };
-    Group_Pack_Matcher group_matcher { args_matcher };
-    Call_Matcher call_matcher { group_matcher };
 
-    const Processing_Status match_status
-        = call_matcher.match_call(call, context, make_fail_callback(), Processing_Status::error);
+    const Processing_Status match_status = match_call(parameters, call, context);
     if (match_status != Processing_Status::ok) {
         return match_status;
     }

--- a/src/main/cpp/directives/code_point.cpp
+++ b/src/main/cpp/directives/code_point.cpp
@@ -43,13 +43,10 @@ Result<char32_t, Processing_Status>
 Char_By_Num_Behavior::get_code_point(const Invocation& call, Context& context) const
 {
     Integer_Matcher num_matcher;
-    Group_Member_Matcher num_member { u8"num", Optionality::mandatory, num_matcher };
-    Group_Member_Matcher* matchers[] { &num_member };
-    Pack_Usual_Matcher args_matcher { matchers };
-    Group_Pack_Matcher group_matcher { args_matcher };
-    Call_Matcher call_matcher { group_matcher };
+    Parameter num_param { u8"num", Optionality::mandatory, num_matcher };
+    Parameter* const parameters[] { &num_param };
 
-    const auto args_status = call_matcher.match_call(call, context, make_fail_callback());
+    const auto args_status = match_call(parameters, call, context);
     if (args_status != Processing_Status::ok) {
         return args_status;
     }
@@ -85,13 +82,10 @@ Char_By_Name_Behavior::get_code_point(const Invocation& call, Context& context) 
     constexpr auto error_point = char32_t(-1);
 
     String_Matcher name_matcher { context.get_transient_memory() };
-    Group_Member_Matcher name_member { u8"name", Optionality::mandatory, name_matcher };
-    Group_Member_Matcher* matchers[] { &name_member };
-    Pack_Usual_Matcher args_matcher { matchers };
-    Group_Pack_Matcher group_matcher { args_matcher };
-    Call_Matcher call_matcher { group_matcher };
+    Parameter name_param { u8"name", Optionality::mandatory, name_matcher };
+    Parameter* const parameters[] { &name_param };
 
-    const auto args_status = call_matcher.match_call(call, context, make_fail_callback());
+    const auto args_status = match_call(parameters, call, context);
     if (args_status != Processing_Status::ok) {
         return args_status;
     }
@@ -116,13 +110,10 @@ Result<Big_Int, Processing_Status>
 Char_Get_Num_Behavior::do_evaluate(const Invocation& call, Context& context) const
 {
     String_Matcher x_matcher { context.get_transient_memory() };
-    Group_Member_Matcher x_member { u8"x", Optionality::mandatory, x_matcher };
-    Group_Member_Matcher* matchers[] { &x_member };
-    Pack_Usual_Matcher args_matcher { matchers };
-    Group_Pack_Matcher group_matcher { args_matcher };
-    Call_Matcher call_matcher { group_matcher };
+    Parameter x_parameter { u8"x", Optionality::mandatory, x_matcher };
+    Parameter* const parameters[] { &x_parameter };
 
-    const auto args_status = call_matcher.match_call(call, context, make_fail_callback());
+    const auto args_status = match_call(parameters, call, context);
     if (args_status != Processing_Status::ok) {
         return args_status;
     }
@@ -151,7 +142,7 @@ Char_Get_Num_Behavior::do_evaluate(const Invocation& call, Context& context) con
     if (std::size_t(length) != input_text.size()) {
         COWEL_ASSERT(std::size_t(length) <= input_text.size());
         context.try_warning(
-            diagnostic::ignored_content, call.directive.get_source_span(),
+            diagnostic::ignored_input, call.directive.get_source_span(),
             u8"Some of the code units inside were ignored because only the first given code point "
             u8"is converted. "
             u8"This can happen if you type a glyph that consist of multiple "

--- a/src/main/cpp/directives/files.cpp
+++ b/src/main/cpp/directives/files.cpp
@@ -45,15 +45,10 @@ Processing_Status
 Include_Text_Behavior::do_evaluate(String_Sink& out, const Invocation& call, Context& context) const
 {
     String_Matcher path_matcher { context.get_transient_memory() };
-    Group_Member_Matcher path_member { u8"path", Optionality::mandatory, path_matcher };
-    Group_Member_Matcher* matchers[] { &path_member };
-    Pack_Usual_Matcher args_matcher { matchers };
-    Group_Pack_Matcher group_matcher { args_matcher };
-    Call_Matcher call_matcher { group_matcher };
+    Parameter path_param { u8"path", Optionality::mandatory, path_matcher };
+    Parameter* const parameters[] { &path_param };
 
-    const auto match_status = call_matcher.match_call(
-        call, context, make_fail_callback<Severity::fatal>(), Processing_Status::fatal
-    );
+    const auto match_status = match_call_fatal_error(parameters, call, context);
     if (match_status != Processing_Status::ok) {
         return match_status;
     }
@@ -89,15 +84,10 @@ Processing_Status
 Include_Behavior::splice(Content_Policy& out, const Invocation& call, Context& context) const
 {
     String_Matcher path_matcher { context.get_transient_memory() };
-    Group_Member_Matcher path_member { u8"path", Optionality::mandatory, path_matcher };
-    Group_Member_Matcher* matchers[] { &path_member };
-    Pack_Usual_Matcher args_matcher { matchers };
-    Group_Pack_Matcher group_matcher { args_matcher };
-    Call_Matcher call_matcher { group_matcher };
+    Parameter path_param { u8"path", Optionality::mandatory, path_matcher };
+    Parameter* const parameters[] { &path_param };
 
-    const auto match_status = call_matcher.match_call(
-        call, context, make_fail_callback<Severity::fatal>(), Processing_Status::fatal
-    );
+    const auto match_status = match_call_fatal_error(parameters, call, context);
     if (match_status != Processing_Status::ok) {
         return match_status;
     }

--- a/src/main/cpp/directives/heading.cpp
+++ b/src/main/cpp/directives/heading.cpp
@@ -36,14 +36,15 @@ namespace {
 [[nodiscard]]
 Processing_Status synthesize_id(
     std::pmr::vector<char8_t>& out,
-    std::span<const ast::Markup_Element> content,
-    Frame_Index content_frame,
+    const Value& content,
+    const File_Source_Span& error_location,
     Context& context
 )
 {
+    COWEL_ASSERT(content.is_block());
     // TODO: diagnostic on bad status
     // TODO: disallow side effects, or maybe use content policies to pull out just the text?
-    const auto status = splice_to_plaintext(out, content, content_frame, context);
+    const auto status = splice_value_to_plaintext(out, content, error_location, context);
     if (status != Processing_Status::ok) {
         return status;
     }
@@ -63,25 +64,20 @@ Processing_Status
 Heading_Behavior::splice(Content_Policy& out, const Invocation& call, Context& context) const
 {
     Spliceable_To_String_Matcher id_matcher { context.get_transient_memory() };
-    Group_Member_Matcher id_member { u8"id"sv, Optionality::optional, id_matcher };
+    Parameter id_param { u8"id"sv, Optionality::optional, id_matcher };
     Boolean_Matcher listed_boolean;
-    Group_Member_Matcher listed_member { u8"listed"sv, Optionality::optional, listed_boolean };
+    Parameter listed_param { u8"listed"sv, Optionality::optional, listed_boolean };
     Boolean_Matcher show_number_boolean;
-    Group_Member_Matcher show_number_member { u8"show_number"sv, Optionality::optional,
-                                              show_number_boolean };
-    Group_Pack_Named_Lazy_Spliceable_Matcher attr_group;
-    Group_Member_Matcher attr_member { u8"attr"sv, Optionality::optional, attr_group };
-    Group_Member_Matcher* const parameters[] {
-        &id_member,
-        &listed_member,
-        &show_number_member,
-        &attr_member,
+    Parameter show_number_param { u8"show_number"sv, Optionality::optional, show_number_boolean };
+    Group_Pack_Named_Str_Matcher attr_group;
+    Parameter attr_param { u8"attr"sv, Optionality::optional, attr_group };
+    Block_Matcher content_matcher;
+    Parameter content_param { u8"content"sv, Optionality::mandatory, content_matcher };
+    Parameter* const parameters[] {
+        &id_param, &listed_param, &show_number_param, &attr_param, &content_param,
     };
-    Pack_Usual_Matcher args_matcher { parameters };
-    Group_Pack_Matcher group_matcher { args_matcher };
-    Call_Matcher call_matcher { group_matcher };
 
-    const auto match_status = call_matcher.match_call(call, context, make_fail_callback());
+    const auto match_status = match_call(parameters, call, context);
     if (match_status != Processing_Status::ok) {
         return status_is_error(match_status) ? try_generate_error(out, call, context, match_status)
                                              : match_status;
@@ -119,7 +115,7 @@ Heading_Behavior::splice(Content_Policy& out, const Invocation& call, Context& c
         }
 
         const auto status = synthesize_id(
-            synthesized_id_buffer, call.get_content_span(), call.content_frame, context
+            synthesized_id_buffer, content_matcher.get(), content_matcher.get_location(), context
         );
         return {
             .status = status,
@@ -142,11 +138,8 @@ Heading_Behavior::splice(Content_Policy& out, const Invocation& call, Context& c
     if (id.exists) {
         attributes.write_id(id.string);
     }
-    const auto attributes_status = attr_group.was_matched()
-        ? named_arguments_to_attributes(
-              attributes, attr_group.get().get_members(), attr_group.get_frame(), context
-          )
-        : Processing_Status::ok;
+    const Processing_Status attributes_status
+        = named_arguments_to_attributes_or_error(attributes, attr_group, context);
     attributes.end();
     current_status = status_concat(current_status, attributes_status);
     if (status_is_break(attributes_status)) {
@@ -160,8 +153,7 @@ Heading_Behavior::splice(Content_Policy& out, const Invocation& call, Context& c
     {
         Capturing_Ref_Text_Sink heading_sink { heading_html, Output_Language::html };
         HTML_Content_Policy html_policy { heading_sink };
-        const auto heading_status
-            = splice_all(html_policy, call.get_content_span(), call.content_frame, context);
+        const auto heading_status = content_matcher.get().splice_block(html_policy, context);
         current_status = status_concat(current_status, heading_status);
         if (status_is_break(heading_status)) {
             writer.close_tag(tag_name);
@@ -283,35 +275,21 @@ namespace {
 
 [[nodiscard]]
 Processing_Status with_section_name(
-    Content_Policy& out,
+    const std::u8string_view name,
     const Invocation& call,
     Context& context,
-    std::u8string_view no_section_diagnostic,
-    Function_Ref<Processing_Status(std::u8string_view section)> action
+    const std::u8string_view no_section_diagnostic,
+    const Function_Ref<Processing_Status(std::u8string_view section)> action
 )
 {
-    Spliceable_To_String_Matcher section_matcher { context.get_transient_memory() };
-    Group_Member_Matcher section_member { u8"section"sv, Optionality::mandatory, section_matcher };
-    Group_Member_Matcher* parameters[] { &section_member };
-    Pack_Usual_Matcher args_matcher { parameters };
-    Group_Pack_Matcher group_matcher { args_matcher };
-    Call_Matcher call_matcher { group_matcher };
-
-    const auto match_status = call_matcher.match_call(call, context, make_fail_callback());
-    if (match_status != Processing_Status::ok) {
-        return status_is_error(match_status) ? try_generate_error(out, call, context, match_status)
-                                             : match_status;
-    }
-
-    const auto section_string = as_u8string_view(section_matcher.get());
-    if (section_string.empty()) {
+    if (name.empty()) {
         context.try_error(
             no_section_diagnostic, call.directive.get_source_span(), u8"No section was provided."sv
         );
         return Processing_Status::error;
     }
 
-    return action(section_string);
+    return action(name);
 }
 
 } // namespace
@@ -319,26 +297,54 @@ Processing_Status with_section_name(
 Processing_Status
 There_Behavior::splice(Content_Policy& out, const Invocation& call, Context& context) const
 {
+    String_Matcher section_matcher { context.get_transient_memory() };
+    Parameter section_param { u8"section"sv, Optionality::mandatory, section_matcher };
+    Block_Matcher content_matcher;
+    Parameter content_param { u8"content"sv, Optionality::mandatory, content_matcher };
+    Parameter* const parameters[] { &section_param, &content_param };
+
+    const auto match_status = match_call(parameters, call, context);
+    if (match_status != Processing_Status::ok) {
+        return status_is_error(match_status) ? try_generate_error(out, call, context, match_status)
+                                             : match_status;
+    }
+
     const auto action = [&](std::u8string_view section) -> Processing_Status {
         const auto scope = context.get_sections().go_to_scoped(section);
-        return splice_all(
-            context.get_sections().current_policy(), call.get_content_span(), call.content_frame,
+        return content_matcher.get().splice_block(
+            context.get_sections().current_policy(), //
             context
         );
     };
-    return with_section_name(out, call, context, diagnostic::there::no_section, action);
+    return with_section_name(
+        section_matcher.get(), call, context, diagnostic::there::no_section, action
+    );
 }
 
 Processing_Status
 Here_Behavior::splice(Content_Policy& out, const Invocation& call, Context& context) const
 {
+    String_Matcher section_matcher { context.get_transient_memory() };
+    Parameter section_param { u8"section"sv, Optionality::mandatory, section_matcher };
+    Block_Matcher content_matcher;
+    Parameter content_param { u8"content"sv, Optionality::mandatory, content_matcher };
+    Parameter* const parameters[] { &section_param, &content_param };
+
+    const auto match_status = match_call(parameters, call, context);
+    if (match_status != Processing_Status::ok) {
+        return status_is_error(match_status) ? try_generate_error(out, call, context, match_status)
+                                             : match_status;
+    }
+
     ensure_paragraph_matches_display(out, m_display);
 
     const auto action = [&](std::u8string_view section) -> Processing_Status {
         reference_section(out, section);
         return Processing_Status::ok;
     };
-    return with_section_name(out, call, context, diagnostic::here::no_section, action);
+    return with_section_name(
+        section_matcher.get(), call, context, diagnostic::here::no_section, action
+    );
 }
 
 Processing_Status

--- a/src/main/cpp/directives/html_entity.cpp
+++ b/src/main/cpp/directives/html_entity.cpp
@@ -94,13 +94,10 @@ Result<Short_String_Value, Processing_Status>
 Char_By_Entity_Behavior::do_evaluate(const Invocation& call, Context& context) const
 {
     String_Matcher name_matcher { context.get_transient_memory() };
-    Group_Member_Matcher name_member { u8"name", Optionality::mandatory, name_matcher };
-    Group_Member_Matcher* matchers[] { &name_member };
-    Pack_Usual_Matcher args_matcher { matchers };
-    Group_Pack_Matcher group_matcher { args_matcher };
-    Call_Matcher call_matcher { group_matcher };
+    Parameter name_param { u8"name", Optionality::mandatory, name_matcher };
+    Parameter* const parameters[] { &name_param };
 
-    const auto args_status = call_matcher.match_call(call, context, make_fail_callback());
+    const auto args_status = match_call(parameters, call, context);
     if (args_status != Processing_Status::ok) {
         return args_status;
     }

--- a/src/main/cpp/directives/invoke.cpp
+++ b/src/main/cpp/directives/invoke.cpp
@@ -17,16 +17,12 @@ Processing_Status
 Invoke_Behavior::splice(Content_Policy& out, const Invocation& call, Context& context) const
 {
     Spliceable_To_String_Matcher directive_name_string { context.get_transient_memory() };
-    Group_Member_Matcher string_argument { u8"name", Optionality::mandatory,
-                                           directive_name_string };
-    Group_Member_Matcher* parameters[] { &string_argument };
-    Pack_Usual_Matcher args_matcher { parameters };
-    Group_Pack_Matcher group_matcher { args_matcher };
-    Call_Matcher call_matcher { group_matcher };
+    Parameter string_param { u8"name", Optionality::mandatory, directive_name_string };
+    Block_Matcher content_matcher;
+    Parameter content_param { u8"content"sv, Optionality::optional, content_matcher };
+    Parameter* const parameters[] { &string_param, &content_param };
 
-    const auto match_status = call_matcher.match_call(
-        call, context, make_fail_callback<Severity::fatal>(), Processing_Status::error
-    );
+    const auto match_status = match_call(parameters, call, context);
     if (match_status != Processing_Status::ok) {
         return status_is_error(match_status) ? try_generate_error(out, call, context, match_status)
                                              : match_status;

--- a/src/main/cpp/directives/literal.cpp
+++ b/src/main/cpp/directives/literal.cpp
@@ -24,10 +24,13 @@ namespace cowel {
 Processing_Status
 HTML_Raw_Text_Behavior::splice(Content_Policy& out, const Invocation& call, Context& context) const
 {
-    Group_Pack_Named_Lazy_Spliceable_Matcher args_matcher {};
-    Call_Matcher call_matcher { args_matcher };
+    Group_Pack_Named_Str_Matcher attr_matcher {};
+    Parameter attr_param { u8"attr"sv, Optionality::optional, attr_matcher };
+    Block_Matcher content_matcher;
+    Parameter content_param { u8"content"sv, Optionality::mandatory, content_matcher };
+    Parameter* const parameters[] { &attr_param, &content_param };
 
-    const auto match_status = call_matcher.match_call(call, context, make_fail_callback());
+    const auto match_status = match_call(parameters, call, context);
     if (match_status != Processing_Status::ok) {
         return match_status;
     }
@@ -37,18 +40,15 @@ HTML_Raw_Text_Behavior::splice(Content_Policy& out, const Invocation& call, Cont
     HTML_Writer_Buffer buffer { out, Output_Language::html };
     Text_Buffer_HTML_Writer writer { buffer };
     Text_Buffer_Attribute_Writer attributes = writer.open_tag_with_attributes(m_tag_name);
-    const auto attributes_status = named_arguments_to_attributes(
-        attributes, call.get_arguments_span(), call.content_frame, context
-    );
+    const Processing_Status attributes_status
+        = named_arguments_to_attributes_or_error(attributes, attr_matcher, context);
     attributes.end();
-    if (status_is_break(attributes_status)) {
-        return attributes_status;
-    }
     Processing_Status status = attributes_status;
 
     std::pmr::vector<char8_t> raw_text { context.get_transient_memory() };
-    const auto content_status
-        = splice_to_plaintext(raw_text, call.get_content_span(), call.content_frame, context);
+    const auto content_status = splice_value_to_plaintext(
+        raw_text, content_matcher.get(), content_matcher.get_location(), context
+    );
     status = status_concat(status, content_status);
     if (status_is_continue(content_status)) {
         COWEL_ASSERT(m_tag_name == u8"style"sv || m_tag_name == u8"script"sv);

--- a/src/main/cpp/directives/macros.cpp
+++ b/src/main/cpp/directives/macros.cpp
@@ -38,7 +38,7 @@ struct Put_Named {
     /// @param members The group members, usually call arguments.
     /// @param frame The content frame of the call.
     [[nodiscard]]
-    Result<const ast::Group_Member*, Processing_Status>
+    Result<std::optional<Argument>, Processing_Status>
     find(std::span<const ast::Group_Member> members, Frame_Index frame) const
     {
         for (const ast::Group_Member& arg : members) {
@@ -62,19 +62,19 @@ struct Put_Named {
                 //       which is probably not desirable.
                 //       However, cowel_macro and cowel_put are kinda on the chopping block,
                 //       so it's not worth solving this right now.
-                const Result<Value, Processing_Status> name_value
+                Result<Value, Processing_Status> name_value
                     = evaluate(arg.get_name(), frame, context);
                 if (!name_value) {
                     return name_value.error();
                 }
                 if (name_value->as_string() == needle_name) {
-                    return &arg;
+                    return std::optional<Argument>(Argument::named(std::move(*name_value), arg));
                 }
                 continue;
             }
             }
         }
-        return nullptr;
+        return std::optional<Argument> {};
     }
 };
 
@@ -89,7 +89,7 @@ struct Put_Positional {
     /// @param members The group members, usually call arguments.
     /// @param frame The content frame of the call.
     [[nodiscard]]
-    const ast::Group_Member* find(std::span<const ast::Group_Member> members, Frame_Index frame)
+    std::optional<Argument> find(std::span<const ast::Group_Member> members, Frame_Index frame)
     {
         for (const ast::Group_Member& arg : members) {
             switch (arg.get_kind()) {
@@ -98,7 +98,7 @@ struct Put_Positional {
             }
             case ast::Member_Kind::ellipsis: {
                 const Stack_Frame& ellipsis_frame = context.get_call_stack()[frame];
-                const auto* maybe_result = find(
+                auto maybe_result = find(
                     ellipsis_frame.invocation.get_arguments_span(),
                     ellipsis_frame.invocation.content_frame
                 );
@@ -109,7 +109,7 @@ struct Put_Positional {
             }
             case ast::Member_Kind::positional: {
                 if (needle_index == index++) {
-                    return &arg;
+                    return Argument ::positional(arg);
                 }
                 continue;
             }
@@ -123,11 +123,13 @@ struct Put_Positional {
 
 Processing_Status Macro_Behavior::do_evaluate(const Invocation& call, Context& context) const
 {
-    Group_Pack_Value_Matcher strings { context.get_transient_memory() };
-    Call_Matcher call_matcher { strings };
+    Pack_Of_Type_Matcher names { Type::pack_of(&Type::str) };
+    Parameter names_param { u8"names"sv, Optionality::optional, names };
+    Block_Matcher content_matcher;
+    Parameter content_param { u8"content"sv, Optionality::mandatory, content_matcher };
+    Parameter* const parameters[] { &names_param, &content_param };
 
-    const Processing_Status match_status
-        = call_matcher.match_call(call, context, make_fail_callback(), Processing_Status::fatal);
+    const Processing_Status match_status = match_call_fatal_error(parameters, call, context);
     switch (match_status) {
     case Processing_Status::ok: break;
     case Processing_Status::brk:
@@ -143,7 +145,7 @@ Processing_Status Macro_Behavior::do_evaluate(const Invocation& call, Context& c
     }
     }
 
-    for (const auto& [alias_name, location] : strings.get_values()) {
+    for (const auto& [alias_name, location] : names.get()) {
         if (!alias_name.is_str()) {
             context.try_error(
                 diagnostic::type_mismatch, location,
@@ -161,7 +163,7 @@ Processing_Status Macro_Behavior::do_evaluate(const Invocation& call, Context& c
         }
     }
 
-    for (const auto& [alias_name_value, location] : strings.get_values()) {
+    for (const auto& [alias_name_value, location] : names.get()) {
         const std::u8string_view alias_name = alias_name_value.as_string();
         if (alias_name.empty()) {
             context.try_fatal(
@@ -206,11 +208,9 @@ Processing_Status Macro_Behavior::do_evaluate(const Invocation& call, Context& c
     return Processing_Status::ok;
 }
 
-Result<const ast::Expression*, Processing_Status>
+Result<Argument, Processing_Status>
 Put_Behavior::resolve(const Invocation& call, Context& context) const
 {
-    constexpr const ast::Expression* found_content_result {};
-
     if (call.content_frame == Frame_Index::root) {
         context.try_error(
             diagnostic::put_outside, call.directive.get_source_span(),
@@ -224,14 +224,13 @@ Put_Behavior::resolve(const Invocation& call, Context& context) const
     static constexpr auto else_type = Type::union_of(else_alternatives);
     static_assert(else_type.is_canonical());
 
-    Lazy_Value_Of_Type_Matcher else_matcher { &else_type };
-    Group_Member_Matcher else_member { u8"else"sv, Optionality::optional, else_matcher };
-    Group_Member_Matcher* const parameters[] { &else_member };
-    Pack_Usual_Matcher args_matcher { parameters };
-    Group_Pack_Matcher group_matcher { args_matcher };
-    Call_Matcher call_matcher { group_matcher };
+    Lazy_Value_Of_Type_Matcher else_matcher { else_type };
+    Parameter else_param { u8"else"sv, Optionality::optional, else_matcher };
+    Block_Matcher content_matcher;
+    Parameter content_param { u8"content"sv, Optionality::optional, content_matcher };
+    Parameter* const parameters[] { &else_param, &content_param };
 
-    const auto match_status = call_matcher.match_call(call, context, make_fail_callback());
+    const auto match_status = match_call(parameters, call, context);
     if (match_status != Processing_Status::ok) {
         return match_status;
     }
@@ -239,9 +238,17 @@ Put_Behavior::resolve(const Invocation& call, Context& context) const
     Call_Stack& stack = context.get_call_stack();
     const Invocation& target_invocation = stack[call.content_frame].invocation;
 
-    // Simple case like \put where we expand the given contents.
-    if (call.has_empty_content()) {
-        return found_content_result;
+    // Simple case like \cowel_put where we expand the given contents.
+    if (!content_matcher.was_matched()) {
+        if (!target_invocation.content) {
+            context.try_error(
+                diagnostic::put_invalid, call.directive.get_source_span(),
+                u8"\\cowel_put attempted to expand a block argument, but none was provided. "
+                u8"Use \\cowel_put(else={}) to silence such cases."sv
+            );
+            return Processing_Status::error;
+        }
+        return Argument::block(*target_invocation.content);
     }
 
     const bool has_else = else_matcher.was_matched();
@@ -256,17 +263,19 @@ Put_Behavior::resolve(const Invocation& call, Context& context) const
 
     // Simple case like \put where we expand the given contents.
     if (target_string.empty()) {
-        return found_content_result;
+        // FIXME: error if need be
+        COWEL_ASSERT(target_invocation.content);
+        return Argument::block(*target_invocation.content);
     }
 
     const std::optional<std::size_t> needle_index = from_characters<std::size_t>(target_string);
-    const auto arg_result = [&] -> Result<const ast::Group_Member*, Processing_Status> {
+    const auto arg_result = [&] -> Result<std::optional<Argument>, Processing_Status> {
         if (needle_index) {
             Put_Positional expand_positional {
                 .context = context,
                 .needle_index = *needle_index,
             };
-            const ast::Group_Member* const maybe_result = expand_positional.find(
+            std::optional<Argument> maybe_result = expand_positional.find(
                 target_invocation.get_arguments_span(), target_invocation.content_frame
             );
             if (!maybe_result && !has_else) {
@@ -293,7 +302,7 @@ Put_Behavior::resolve(const Invocation& call, Context& context) const
                 .context = context,
                 .needle_name = target_string,
             };
-            Result<const ast::Group_Member*, Processing_Status> maybe_result = expand_named.find(
+            Result<std::optional<Argument>, Processing_Status> maybe_result = expand_named.find(
                 target_invocation.get_arguments_span(), target_invocation.content_frame
             );
             if (!maybe_result) {
@@ -318,16 +327,16 @@ Put_Behavior::resolve(const Invocation& call, Context& context) const
     if (!arg_result) {
         return arg_result.error();
     }
-    const auto* const arg = *arg_result;
+    const std::optional<Argument>& arg = *arg_result;
     if (!arg) {
         if (!has_else) {
             // Error has already been printed above.
             return Processing_Status::error;
         }
-        return &else_matcher.get();
+        return else_matcher.get();
     }
 
-    return &arg->get_value();
+    return *arg;
 }
 
 // FIXME: Something is seriously inconsistent here.
@@ -338,7 +347,7 @@ Put_Behavior::resolve(const Invocation& call, Context& context) const
 Result<Value, Processing_Status>
 Put_Behavior::evaluate(const Invocation& call, Context& context) const
 {
-    const Result<const ast::Expression*, Processing_Status> result = resolve(call, context);
+    const Result<Argument, Processing_Status> result = resolve(call, context);
     if (!result) {
         return result.error();
     }
@@ -346,21 +355,14 @@ Put_Behavior::evaluate(const Invocation& call, Context& context) const
     Call_Stack& stack = context.get_call_stack();
     const Invocation& target_invocation = stack[call.content_frame].invocation;
 
-    if (*result == nullptr) {
-        // FIXME: I'm pretty sure nothing so far has guaranteed that the block exists.
-        //        We don't need to worry about that for splicing,
-        //        but when evaluating, we need to obtain some Value.
-        COWEL_ASSERT(target_invocation.content);
-        return Value::block(*target_invocation.content, target_invocation.content_frame);
-    }
-    return evaluate_expression(**result, target_invocation.content_frame, context);
+    return result->evaluate(target_invocation.content_frame, context);
 }
 
 Processing_Status
 Put_Behavior::splice(Content_Policy& out, const Invocation& call, Context& context) const
 {
     // FIXME: Maybe this function should just go away
-    const Result<const ast::Expression*, Processing_Status> result = resolve(call, context);
+    const Result<Argument, Processing_Status> result = resolve(call, context);
     if (!result) {
         return try_generate_error(out, call, context, result.error());
     }
@@ -369,14 +371,7 @@ Put_Behavior::splice(Content_Policy& out, const Invocation& call, Context& conte
     const Invocation& target_invocation = stack[call.content_frame].invocation;
 
     try_inherit_paragraph(out);
-    if (*result == nullptr) {
-        return splice_all(
-            out, target_invocation.get_content_span(), target_invocation.content_frame, context
-        );
-    }
-    // FIXME: This may not be a spliceable value,
-    //        such as when a group was found.
-    return splice_expression(out, **result, target_invocation.content_frame, context);
+    return result->splice(out, target_invocation.content_frame, context);
 }
 
 Processing_Status

--- a/src/main/cpp/directives/macros.cpp
+++ b/src/main/cpp/directives/macros.cpp
@@ -109,7 +109,7 @@ struct Put_Positional {
             }
             case ast::Member_Kind::positional: {
                 if (needle_index == index++) {
-                    return Argument ::positional(arg);
+                    return Argument::positional(arg);
                 }
                 continue;
             }

--- a/src/main/cpp/directives/math.cpp
+++ b/src/main/cpp/directives/math.cpp
@@ -90,94 +90,118 @@ constexpr std::ptrdiff_t mathml_element_index(std::u8string_view name)
 static_assert(mathml_permits_text_bits[mathml_element_index(u8"mi")]);
 static_assert(!mathml_permits_text_bits[mathml_element_index(u8"munderover")]);
 
-[[nodiscard]]
-Processing_Status to_math_html(
-    Content_Policy& out,
-    std::span<const ast::Markup_Element> contents,
-    Frame_Index content_frame,
-    Context& context,
-    bool permit_text = false
-)
-{
-    return process_greedy(contents, [&](const ast::Markup_Element& c) -> Processing_Status {
-        const auto* const d = c.try_as_directive();
-        if (!d) {
-            if (!permit_text) {
-                const auto* const t = c.try_as_primary();
-                if (t && t->get_kind() == ast::Primary_Kind::text) {
-                    const bool is_blank_text = std::ranges::all_of(t->get_source(), [](char8_t c) {
-                        return is_ascii_blank(c);
-                    });
-                    if (!is_blank_text) {
-                        context.try_warning(
-                            diagnostic::math::text, c.get_source_span(),
-                            u8"Text cannot appear in this context. "
-                            u8"MathML requires text to be enclosed in <mi>, <mn>, etc., "
-                            u8"which correspond to \\mi, \\mn, and other pseudo-directives."sv
-                        );
-                    }
-                }
+constexpr Type bool_or_str_types[] { Type::boolean, Type::str };
+constexpr auto bool_or_str = Type::union_of(bool_or_str_types);
+constexpr auto named_bool_or_str = Type::named(&bool_or_str);
+constexpr auto pack_named_bool_or_str = Type::pack_of(&named_bool_or_str);
+static_assert(pack_named_bool_or_str.is_canonical());
+
+struct Math_Content_Policy final : HTML_Content_Policy {
+private:
+    bool m_permit_text;
+
+public:
+    [[nodiscard]]
+    Math_Content_Policy(Text_Sink& parent, const bool permit_text)
+        : Text_Sink { Output_Language::html }
+        , Content_Policy { Output_Language::html }
+        , HTML_Content_Policy { parent }
+        , m_permit_text { permit_text }
+    {
+    }
+
+    [[nodiscard]]
+    Processing_Status
+    consume(const ast::Primary& node, const Frame_Index frame, Context& context) override
+    {
+        const auto kind = node.get_kind();
+        const bool attempt_diagnose_text = !m_permit_text
+            && (kind == ast::Primary_Kind::text || kind == ast::Primary_Kind::escape);
+        if (attempt_diagnose_text) {
+            const bool is_non_blank_escape
+                = kind == ast::Primary_Kind::escape && !expand_escape(node).empty();
+            const bool is_non_blank_text = kind == ast::Primary_Kind::text
+                && !std::ranges::all_of(node.get_source(),
+                                        [](const char8_t c) { return is_ascii_blank(c); });
+            if (is_non_blank_escape || is_non_blank_text) {
+                context.try_warning(
+                    diagnostic::math::text, node.get_source_span(),
+                    u8"Text cannot appear in this context. "
+                    u8"MathML requires text to be enclosed in <mi>, <mn>, etc., "
+                    u8"which correspond to \\mi, \\mn, and other pseudo-directives."sv
+                );
             }
-            return out.consume_content(c, content_frame, context);
         }
-        const std::u8string_view name_string = d->get_name();
+        return HTML_Content_Policy::consume(node, frame, context);
+    }
+
+    [[nodiscard]]
+    Processing_Status
+    consume(const ast::Directive& d, const Frame_Index content_frame, Context& context) override
+    {
+        const std::u8string_view name_string = d.get_name();
         const std::ptrdiff_t index = mathml_element_index(name_string);
         if (index < 0) {
-            return out.consume(*d, content_frame, context);
+            return HTML_Content_Policy::consume(d, content_frame, context);
         }
 
-        Group_Pack_Named_Lazy_Spliceable_Matcher args_matcher;
+        Pack_Named_Of_Type_Matcher attr_matcher { pack_named_bool_or_str };
+        Parameter args_param { u8"attr"sv, Optionality::optional, attr_matcher };
+        Block_Matcher content_matcher;
+        Parameter content_param { u8"content"sv, Optionality::mandatory, content_matcher };
+        Parameter* const parameters[] { &args_param, &content_param };
 
-        const auto match_status = args_matcher.match_group(
-            d->get_arguments(), content_frame, context,
-            {
-                .emit = make_fail_callback(),
-                .status = Processing_Status::error,
-                .location = d->get_name_span(),
-            }
-        );
+        Invocation call {
+            .name = name_string,
+            .directive = d,
+            .arguments = d.get_arguments(),
+            .content = d.get_content(),
+            .content_frame = content_frame,
+            .call_frame = content_frame,
+        };
+        const auto match_status = match_call(parameters, call, context);
         if (match_status != Processing_Status::ok) {
             return match_status;
         }
 
         // directive names are HTML tag names
         const HTML_Tag_Name name { Unchecked {}, name_string };
-        HTML_Writer_Buffer buffer { out, Output_Language::html };
+        HTML_Writer_Buffer buffer { *this, Output_Language::html };
         Text_Buffer_HTML_Writer writer { buffer };
         auto attributes = writer.open_tag_with_attributes(name);
-        const auto attributes_status = named_arguments_to_attributes(
-            attributes, d->get_argument_span(), content_frame, context
-        );
+        const auto attributes_status
+            = named_arguments_to_attributes_or_error(attributes, attr_matcher, context);
         attributes.end();
-        if (status_is_break(attributes_status)) {
-            writer.close_tag(name);
-            buffer.flush();
-            return attributes_status;
-        }
 
         buffer.flush();
+
         const bool child_permits_text = mathml_permits_text_bits[std::size_t(index)];
-        const auto nested_status
-            = to_math_html(out, d->get_content_span(), content_frame, context, child_permits_text);
+        const bool old_permit_text = std::exchange(m_permit_text, child_permits_text);
+        const auto nested_status = content_matcher.get().splice_block(*this, context);
+        m_permit_text = old_permit_text;
+
         writer.close_tag(name);
         buffer.flush();
         return status_concat(attributes_status, nested_status);
-    });
-}
+    }
+};
 
 } // namespace
 
 Processing_Status
 Math_Behavior::splice(Content_Policy& out, const Invocation& call, Context& context) const
 {
-    constexpr auto tag_name = html_tag::math;
-    const std::u8string_view display_string
-        = m_display == Directive_Display::in_line ? u8"inline" : u8"block";
+    static constexpr auto tag_name = html_tag::math;
+    const auto display_string
+        = m_display == Directive_Display::in_line ? u8"inline"sv : u8"block"sv;
 
-    Group_Pack_Named_Lazy_Spliceable_Matcher args_matcher;
-    Call_Matcher call_matcher { args_matcher };
+    Pack_Named_Of_Type_Matcher attr_matcher { pack_named_bool_or_str };
+    Parameter attr_param { u8"attr"sv, Optionality::optional, attr_matcher };
+    Block_Matcher content_matcher;
+    Parameter content_param { u8"content"sv, Optionality::mandatory, content_matcher };
+    Parameter* const parameters[] { &attr_param, &content_param };
 
-    const auto match_status = call_matcher.match_call(call, context, make_fail_callback());
+    const auto match_status = match_call(parameters, call, context);
     if (match_status != Processing_Status::ok) {
         return status_is_error(match_status) ? try_generate_error(out, call, context, match_status)
                                              : match_status;
@@ -190,19 +214,13 @@ Math_Behavior::splice(Content_Policy& out, const Invocation& call, Context& cont
     Text_Buffer_HTML_Writer writer { buffer };
     auto attributes = writer.open_tag_with_attributes(tag_name);
     attributes.write_display(display_string);
-    const auto attributes_status = named_arguments_to_attributes(
-        attributes, call.get_arguments_span(), call.content_frame, context
-    );
+    const Processing_Status attributes_status
+        = named_arguments_to_attributes_or_error(attributes, attr_matcher, context);
     attributes.end();
-    if (status_is_break(attributes_status)) {
-        writer.close_tag(tag_name);
-        buffer.flush();
-        return attributes_status;
-    }
     buffer.flush();
 
-    const auto nested_status
-        = to_math_html(policy, call.get_content_span(), call.content_frame, context);
+    Math_Content_Policy math_policy { policy, /*permit_text=*/false };
+    const auto nested_status = content_matcher.get().splice_block(math_policy, context);
     writer.close_tag(tag_name);
     buffer.flush();
     return status_concat(attributes_status, nested_status);

--- a/src/main/cpp/directives/paragraph.cpp
+++ b/src/main/cpp/directives/paragraph.cpp
@@ -1,16 +1,11 @@
-#include <string_view>
-
 #include "cowel/policy/paragraph_split.hpp"
 
-#include "cowel/ast.hpp"
 #include "cowel/builtin_directive_set.hpp"
 #include "cowel/content_status.hpp"
 #include "cowel/context.hpp"
-#include "cowel/diagnostic.hpp"
 #include "cowel/fwd.hpp"
 #include "cowel/invocation.hpp"
-
-using namespace std::string_view_literals;
+#include "cowel/parameters.hpp"
 
 namespace cowel {
 namespace {
@@ -23,17 +18,11 @@ Processing_Status control_paragraph(
     Context& context
 )
 {
-    const auto match_status = match_empty_arguments(call, context);
+    const auto match_status = match_call({}, call, context);
     if (match_status != Processing_Status::ok) {
         return match_status;
     }
 
-    if (!call.get_content_span().empty()) {
-        context.try_warning(
-            diagnostic::ignored_content, call.content->get_source_span(),
-            u8"Content in a paragraph control directive is ignored."sv
-        );
-    }
     if (auto* const derived = dynamic_cast<Paragraph_Split_Policy*>(&out)) {
         (derived->*action)();
     }

--- a/src/main/cpp/directives/passthrough.cpp
+++ b/src/main/cpp/directives/passthrough.cpp
@@ -61,21 +61,15 @@ Error_Behavior::splice(Content_Policy& out, const Invocation& call, Context&) co
 }
 
 Processing_Status
-Trim_Behavior::splice(Content_Policy& out, const Invocation& call, Context& context) const
-{
-    // TODO: warn about unused arguments
-    ensure_paragraph_matches_display(out, m_display);
-
-    return splice_all_trimmed(out, call.get_content_span(), call.content_frame, context);
-}
-
-Processing_Status
 Passthrough_Behavior::splice(Content_Policy& out, const Invocation& call, Context& context) const
 {
-    Group_Pack_Named_Lazy_Spliceable_Matcher group_matcher;
-    Call_Matcher call_matcher { group_matcher };
+    Pack_Named_Str_Matcher attr_matcher;
+    Parameter attr_param { u8"attr"sv, Optionality::optional, attr_matcher };
+    Block_Matcher content_matcher;
+    Parameter content_param { u8"content"sv, Optionality::optional, content_matcher };
+    Parameter* const parameters[] { &attr_param, &content_param };
 
-    const auto match_status = call_matcher.match_call(call, context, make_fail_callback());
+    const auto match_status = match_call(parameters, call, context, make_fail_callback());
     if (match_status != Processing_Status::ok) {
         return match_status;
     }
@@ -89,19 +83,14 @@ Passthrough_Behavior::splice(Content_Policy& out, const Invocation& call, Contex
     HTML_Writer_Buffer buffer { out, Output_Language::html };
     Text_Buffer_HTML_Writer writer { buffer };
     Text_Buffer_Attribute_Writer attributes = writer.open_tag_with_attributes(name);
-    const auto attributes_status = named_arguments_to_attributes(
-        attributes, call.get_arguments_span(), call.content_frame, context
-    );
+    const auto attributes_status
+        = named_arguments_to_attributes_or_error(attributes, attr_matcher, context);
     attributes.end();
-    if (status_is_break(attributes_status)) {
-        writer.close_tag(name);
-        buffer.flush();
-        return attributes_status;
-    }
     buffer.flush();
 
-    const auto content_status
-        = splice_all(policy, call.get_content_span(), call.content_frame, context);
+    const auto content_status = content_matcher.has_value()
+        ? content_matcher.get().splice_block(policy, context)
+        : Processing_Status::ok;
     writer.close_tag(name);
     buffer.flush();
     return status_concat(attributes_status, content_status);
@@ -110,28 +99,29 @@ Passthrough_Behavior::splice(Content_Policy& out, const Invocation& call, Contex
 Processing_Status
 HTML_Element_Behavior::splice(Content_Policy& out, const Invocation& call, Context& context) const
 {
-    Spliceable_To_String_Matcher name_string_matcher { context.get_transient_memory() };
-    Group_Member_Matcher name_member_matcher { u8"name"sv, Optionality::mandatory,
-                                               name_string_matcher };
-    Group_Pack_Named_Lazy_Spliceable_Matcher attributes_group_matcher;
-    Group_Member_Matcher attributes_matcher { u8"attr"sv, Optionality::optional,
-                                              attributes_group_matcher };
-    Group_Member_Matcher* parameters[] { &name_member_matcher, &attributes_matcher };
-    Pack_Usual_Matcher args_matcher { parameters };
-    Group_Pack_Matcher group_matcher { args_matcher };
-    Call_Matcher call_matcher { group_matcher };
+    Spliceable_To_String_Matcher name_matcher { context.get_transient_memory() };
+    Parameter name_param { u8"name"sv, Optionality::mandatory, name_matcher };
+    Group_Pack_Named_Str_Matcher attr_matcher;
+    Parameter attr_param { u8"attr"sv, Optionality::optional, attr_matcher };
+    Block_Matcher content_matcher;
+    Parameter content_param { u8"content"sv, Optionality::optional, content_matcher };
 
-    const auto match_status = call_matcher.match_call(call, context, make_fail_callback());
+    Parameter* const parameters[] { &name_param, &attr_param, &content_param };
+    const std::size_t parameter_count
+        = m_self_closing == HTML_Element_Self_Closing::self_closing ? 2 : 3;
+    const auto actual_parameters = std::span { parameters }.subspan(0, parameter_count);
+
+    const auto match_status = match_call(actual_parameters, call, context);
     if (match_status != Processing_Status::ok) {
         return status_is_error(match_status) ? try_generate_error(out, call, context, match_status)
                                              : match_status;
     }
 
-    const auto name_string = as_u8string_view(name_string_matcher.get());
+    const auto name_string = as_u8string_view(name_matcher.get());
     const std::optional<HTML_Tag_Name> name = HTML_Tag_Name::make(name_string);
     if (!name) {
         context.try_error(
-            diagnostic::html_element_name_invalid, name_string_matcher.get_location(),
+            diagnostic::html_element_name_invalid, name_matcher.get_location(),
             joined_char_sequence(
                 {
                     u8"The given tag name \""sv,
@@ -146,31 +136,16 @@ HTML_Element_Behavior::splice(Content_Policy& out, const Invocation& call, Conte
     HTML_Writer_Buffer buffer { out, Output_Language::html };
     Text_Buffer_HTML_Writer writer { buffer };
     auto attributes = writer.open_tag_with_attributes(*name);
-    auto status = [&] -> Processing_Status {
-        if (!attributes_group_matcher.was_matched()) {
-            return Processing_Status ::ok;
-        }
-        return named_arguments_to_attributes(
-            attributes, attributes_group_matcher.get().get_members(),
-            attributes_group_matcher.get_frame(), context
-        );
-    }();
-
+    auto status = named_arguments_to_attributes_or_error(attributes, attr_matcher, context);
     if (m_self_closing == HTML_Element_Self_Closing::self_closing) {
+        COWEL_ASSERT(!content_matcher.was_matched());
         attributes.end_empty();
-        if (!call.get_content_span().empty()) {
-            context.try_warning(
-                diagnostic::ignored_content, call.content->get_source_span(),
-                u8"Content in a self-closing HTML element is ignored."sv
-            );
-        }
     }
     else {
         attributes.end();
         buffer.flush();
-        if (status_is_continue(status)) {
-            const auto content_status
-                = splice_all(out, call.get_content_span(), call.content_frame, context);
+        if (status_is_continue(status) && content_matcher.was_matched()) {
+            const auto content_status = content_matcher.get().splice_block(out, context);
             status = status_concat(status, content_status);
         }
         writer.close_tag(*name);
@@ -185,10 +160,13 @@ HTML_Element_Behavior::splice(Content_Policy& out, const Invocation& call, Conte
 Processing_Status
 In_Tag_Behavior::splice(Content_Policy& out, const Invocation& call, Context& context) const
 {
-    Group_Pack_Named_Lazy_Spliceable_Matcher group_matcher;
-    Call_Matcher call_matcher { group_matcher };
+    Pack_Named_Str_Matcher attr_matcher;
+    Parameter attr_param { u8"attr"sv, Optionality::optional, attr_matcher };
+    Block_Matcher content_matcher;
+    Parameter content_param { u8"content"sv, Optionality::mandatory, content_matcher };
+    Parameter* const parameters[] { &attr_param, &content_param };
 
-    const auto match_status = call_matcher.match_call(call, context, make_fail_callback());
+    const auto match_status = match_call(parameters, call, context);
     if (match_status != Processing_Status::ok) {
         return match_status;
     }
@@ -202,19 +180,12 @@ In_Tag_Behavior::splice(Content_Policy& out, const Invocation& call, Context& co
     Text_Buffer_HTML_Writer writer { buffer };
     auto attributes = writer.open_tag_with_attributes(m_tag_name);
     attributes.write_class(m_class_name);
-    const auto attributes_status = named_arguments_to_attributes(
-        attributes, call.get_arguments_span(), call.content_frame, context
-    );
+    const Processing_Status attributes_status
+        = named_arguments_to_attributes_or_error(attributes, attr_matcher, context);
     attributes.end();
-    if (status_is_break(attributes_status)) {
-        writer.close_tag(m_tag_name);
-        buffer.flush();
-        return attributes_status;
-    }
     buffer.flush();
 
-    const auto content_status
-        = splice_all(policy, call.get_content_span(), call.content_frame, context);
+    const auto content_status = content_matcher.get().splice_block(policy, context);
 
     writer.close_tag(m_tag_name);
     buffer.flush();
@@ -224,10 +195,13 @@ In_Tag_Behavior::splice(Content_Policy& out, const Invocation& call, Context& co
 Processing_Status
 Special_Block_Behavior::splice(Content_Policy& out, const Invocation& call, Context& context) const
 {
-    Group_Pack_Named_Lazy_Spliceable_Matcher group_matcher;
-    Call_Matcher call_matcher { group_matcher };
+    Pack_Named_Str_Matcher attr_matcher;
+    Parameter attr_param { u8"attr"sv, Optionality::optional, attr_matcher };
+    Block_Matcher content_matcher;
+    Parameter content_param { u8"content"sv, Optionality::mandatory, content_matcher };
+    Parameter* const parameters[] { &attr_param, &content_param };
 
-    const auto match_status = call_matcher.match_call(call, context, make_fail_callback());
+    const auto match_status = match_call(parameters, call, context);
     if (match_status != Processing_Status::ok) {
         return match_status;
     }
@@ -246,15 +220,9 @@ Special_Block_Behavior::splice(Content_Policy& out, const Invocation& call, Cont
     HTML_Writer_Buffer buffer { out, Output_Language::html };
     Text_Buffer_HTML_Writer writer { buffer };
     auto attributes = writer.open_tag_with_attributes(m_name);
-    const auto attributes_status = named_arguments_to_attributes(
-        attributes, call.get_arguments_span(), call.content_frame, context
-    );
+    const Processing_Status attributes_status
+        = named_arguments_to_attributes_or_error(attributes, attr_matcher, context);
     attributes.end();
-    if (status_is_break(attributes_status)) {
-        writer.close_tag(m_name);
-        buffer.flush();
-        return attributes_status;
-    }
 
     if (emit_intro) {
         writer.open_tag(html_tag::p);
@@ -265,8 +233,7 @@ Special_Block_Behavior::splice(Content_Policy& out, const Invocation& call, Cont
     }
     buffer.flush();
 
-    const auto content_status
-        = splice_all(policy, call.get_content_span(), call.content_frame, context);
+    const auto content_status = content_matcher.get().splice_block(policy, context);
 
     policy.leave_paragraph();
     writer.close_tag(m_name);
@@ -277,10 +244,13 @@ Special_Block_Behavior::splice(Content_Policy& out, const Invocation& call, Cont
 Processing_Status
 URL_Behavior::splice(Content_Policy& out, const Invocation& call, Context& context) const
 {
-    Group_Pack_Named_Lazy_Spliceable_Matcher group_matcher;
-    Call_Matcher call_matcher { group_matcher };
+    Pack_Named_Str_Matcher attr_matcher;
+    Parameter attr_param { u8"attr"sv, Optionality::optional, attr_matcher };
+    Block_Matcher content_matcher;
+    Parameter content_param { u8"content"sv, Optionality::mandatory, content_matcher };
+    Parameter* const parameters[] { &attr_param, &content_param };
 
-    const auto match_status = call_matcher.match_call(call, context, make_fail_callback());
+    const auto match_status = match_call(parameters, call, context);
     if (match_status != Processing_Status::ok) {
         return match_status;
     }
@@ -289,8 +259,9 @@ URL_Behavior::splice(Content_Policy& out, const Invocation& call, Context& conte
 
     std::pmr::vector<char8_t> url { context.get_transient_memory() };
     append(url, m_url_prefix);
-    const auto text_status
-        = splice_to_plaintext(url, call.get_content_span(), call.content_frame, context);
+    const auto text_status = splice_value_to_plaintext(
+        url, content_matcher.get(), content_matcher.get_location(), context
+    );
     if (text_status != Processing_Status::ok) {
         return text_status;
     }
@@ -300,9 +271,8 @@ URL_Behavior::splice(Content_Policy& out, const Invocation& call, Context& conte
     HTML_Writer_Buffer buffer { out, Output_Language::html };
     Text_Buffer_HTML_Writer writer { buffer };
     auto attributes = writer.open_tag_with_attributes(html_tag::a);
-    const auto attributes_status = named_arguments_to_attributes(
-        attributes, call.get_arguments_span(), call.content_frame, context
-    );
+    const Processing_Status attributes_status
+        = named_arguments_to_attributes_or_error(attributes, attr_matcher, context);
     attributes.write_href(url_string);
     attributes.write_class(u8"sans"sv);
     attributes.end();
@@ -318,21 +288,15 @@ URL_Behavior::splice(Content_Policy& out, const Invocation& call, Context& conte
 Processing_Status
 Self_Closing_Behavior::splice(Content_Policy& out, const Invocation& call, Context& context) const
 {
-    Group_Pack_Named_Lazy_Spliceable_Matcher group_matcher;
-    Call_Matcher call_matcher { group_matcher };
+    Pack_Named_Str_Matcher attr_matcher;
+    Parameter attr_param { u8"attr"sv, Optionality::optional, attr_matcher };
+    Block_Matcher content_matcher;
+    Parameter content_param { u8"content"sv, Optionality::optional, content_matcher };
+    Parameter* const parameters[] { &attr_param, &content_param };
 
-    const auto match_status = call_matcher.match_call(call, context, make_fail_callback());
+    const auto match_status = match_call(parameters, call, context);
     if (match_status != Processing_Status::ok) {
         return match_status;
-    }
-
-    // TODO: this should use some utility function
-    if (!call.get_content_span().empty()) {
-        context.try_warning(
-            diagnostic::ignored_content, call.content->get_source_span(),
-            u8"Content was ignored. Use empty braces,"
-            "i.e. {} to resolve this warning."sv
-        );
     }
 
     ensure_paragraph_matches_display(out, m_display);
@@ -340,9 +304,8 @@ Self_Closing_Behavior::splice(Content_Policy& out, const Invocation& call, Conte
     HTML_Writer_Buffer buffer { out, Output_Language::html };
     Text_Buffer_HTML_Writer writer { buffer };
     auto attributes = writer.open_tag_with_attributes(m_tag_name);
-    const auto status = named_arguments_to_attributes(
-        attributes, call.get_arguments_span(), call.content_frame, context
-    );
+    const Processing_Status status
+        = named_arguments_to_attributes_or_error(attributes, attr_matcher, context);
     attributes.end_empty();
     return status;
 }
@@ -355,14 +318,12 @@ Processing_Status Internal_Expect_Diagnostic_Behavior::splice(
 ) const
 {
     String_Matcher id_matcher { context.get_transient_memory() };
-    Group_Member_Matcher id_member { u8"id"sv, Optionality::mandatory, id_matcher };
-    Group_Member_Matcher* parameters[] { &id_member };
-    Pack_Usual_Matcher args_matcher { parameters };
-    Group_Pack_Matcher group_matcher { args_matcher };
-    Call_Matcher call_matcher { group_matcher };
+    Parameter id_param { u8"id"sv, Optionality::mandatory, id_matcher };
+    Block_Matcher content_matcher;
+    Parameter content_param { u8"content"sv, Optionality::mandatory, content_matcher };
+    Parameter* const parameters[] { &id_param, &content_param };
 
-    if (const auto match_status
-        = call_matcher.match_call(call, context, make_fail_callback(), Processing_Status::fatal);
+    if (const auto match_status = match_call_fatal_error(parameters, call, context);
         match_status != Processing_Status::ok) {
         return match_status;
     }
@@ -381,8 +342,7 @@ Processing_Status Internal_Expect_Diagnostic_Behavior::splice(
         context.get_transient_memory(),
     };
     context.set_logger(expecting_logger);
-    const Processing_Status status
-        = splice_all(out, call.get_content_span(), call.content_frame, context);
+    const Processing_Status status = content_matcher.get().splice_block(out, context);
 
     if (status != m_expected_status) {
         (*old_logger)(Diagnostic {
@@ -411,17 +371,27 @@ Processing_Status Internal_Expect_Diagnostic_Behavior::splice(
         result = Processing_Status::error;
     }
     if (!expecting_logger.was_expected_logged()) {
+        std::pmr::u8string message { context.get_transient_memory() };
+        message += u8"Expected the block to produce the diagnostic \""sv;
+        message += expected_id;
+        message += u8"\", but it was not logged (with the expected severity)."sv;
+        if (!expecting_logger.get_extra_diagnostics().empty()) {
+            message += u8" However, the following additional diagnostics were logged: "sv;
+            for (bool first = true;
+                 const Collected_Diagnostic& extra : expecting_logger.get_extra_diagnostics()) {
+                if (!first) {
+                    message += u8", "sv;
+                }
+                message += extra.id;
+                first = false;
+            }
+        }
+
         (*old_logger)(Diagnostic {
             .severity = Severity::error,
             .id = u8"test.diagnostic"sv,
             .location = call.directive.get_source_span(),
-            .message = joined_char_sequence(
-                {
-                    u8"Expected the block to produce the diagnostic \""sv,
-                    expected_id,
-                    u8"\", but it was not logged (with the expected severity)."sv,
-                }
-            ),
+            .message = as_u8string_view(message),
         });
         result = Processing_Status::error;
     }

--- a/src/main/cpp/directives/policies.cpp
+++ b/src/main/cpp/directives/policies.cpp
@@ -29,26 +29,45 @@ template <typename T>
 [[nodiscard]]
 Processing_Status consume_simply(Content_Policy& out, const Invocation& call, Context& context)
 {
-    const auto match_status = match_empty_arguments(call, context);
+    Block_Matcher content_matcher;
+    Parameter content_param { u8"content"sv, Optionality::mandatory, content_matcher };
+    Parameter* const parameters[] { &content_param };
+
+    const auto match_status = match_call(parameters, call, context);
     if (match_status != Processing_Status::ok) {
         return match_status;
     }
-    T policy { out };
-    return splice_all(policy, call.get_content_span(), call.content_frame, context);
+
+    auto policy = [&] -> T {
+        if constexpr (std::is_same_v<T, Paragraph_Split_Policy>) {
+            return T { out, context.get_transient_memory() };
+        }
+        else if constexpr (std::is_same_v<T, HTML_Content_Policy>) {
+            return ensure_html_policy(out);
+        }
+        else {
+            return T { out };
+        }
+    }();
+    const Processing_Status result = content_matcher.get().splice_block(policy, context);
+    if constexpr (std::is_same_v<T, Paragraph_Split_Policy>) {
+        policy.leave_paragraph();
+    }
+    return result;
 }
 
 [[nodiscard]]
-Processing_Status consume_paragraphs(Content_Policy& out, const Invocation& call, Context& context)
+Processing_Status consume_current(Content_Policy& out, const Invocation& call, Context& context)
 {
-    const auto match_status = match_empty_arguments(call, context);
+    Block_Matcher content_matcher;
+    Parameter content_param { u8"content"sv, Optionality::mandatory, content_matcher };
+    Parameter* const parameters[] { &content_param };
+
+    const auto match_status = match_call(parameters, call, context);
     if (match_status != Processing_Status::ok) {
         return match_status;
     }
-    Paragraph_Split_Policy policy { out, context.get_transient_memory() };
-    const Processing_Status result
-        = splice_all(policy, call.get_content_span(), call.content_frame, context);
-    policy.leave_paragraph();
-    return result;
+    return content_matcher.get().splice_block(out, context);
 }
 
 [[nodiscard]]
@@ -56,21 +75,19 @@ Processing_Status
 consume_syntax_highlighted(Content_Policy& out, const Invocation& call, Context& context)
 {
     Spliceable_To_String_Matcher lang_string { context.get_transient_memory() };
-    Group_Member_Matcher lang_member { u8"lang"sv, Optionality::mandatory, lang_string };
-    Group_Member_Matcher* parameters[] { &lang_member };
-    Pack_Usual_Matcher args_matcher { parameters };
-    Group_Pack_Matcher group_matcher { args_matcher };
-    Call_Matcher call_matcher { group_matcher };
+    Parameter lang_param { u8"lang"sv, Optionality::mandatory, lang_string };
+    Block_Matcher content_matcher;
+    Parameter content_param { u8"content"sv, Optionality::mandatory, content_matcher };
+    Parameter* const parameters[] { &lang_param, &content_param };
 
-    const auto match_status = call_matcher.match_call(call, context, make_fail_callback());
+    const auto match_status = match_call(parameters, call, context);
     if (match_status != Processing_Status::ok) {
         return status_is_error(match_status) ? try_generate_error(out, call, context, match_status)
                                              : match_status;
     }
 
     Syntax_Highlight_Policy policy { context.get_transient_memory() };
-    const Processing_Status consume_status
-        = splice_all(policy, call.get_content_span(), call.content_frame, context);
+    const Processing_Status consume_status = content_matcher.get().splice_block(policy, context);
     const Result<void, Syntax_Highlight_Error> result
         = policy.dump_html_to(out, context, lang_string.get());
     if (!result) {
@@ -87,19 +104,10 @@ Policy_Behavior::splice(Content_Policy& out, const Invocation& call, Context& co
 {
     switch (m_policy) {
     case Known_Content_Policy::current: {
-        const auto match_status = match_empty_arguments(call, context);
-        if (match_status != Processing_Status::ok) {
-            return match_status;
-        }
-        return splice_all(out, call.get_content_span(), call.content_frame, context);
+        return consume_current(out, call, context);
     }
     case Known_Content_Policy::to_html: {
-        const auto match_status = match_empty_arguments(call, context);
-        if (match_status != Processing_Status::ok) {
-            return match_status;
-        }
-        HTML_Content_Policy policy = ensure_html_policy(out);
-        return splice_all(policy, call.get_content_span(), call.content_frame, context);
+        return consume_simply<HTML_Content_Policy>(out, call, context);
     }
     case Known_Content_Policy::highlight: {
         return consume_syntax_highlighted(out, call, context);
@@ -108,7 +116,7 @@ Policy_Behavior::splice(Content_Policy& out, const Invocation& call, Context& co
         return consume_simply<Phantom_Content_Policy>(out, call, context);
     }
     case Known_Content_Policy::paragraphs: {
-        return consume_paragraphs(out, call, context);
+        return consume_simply<Paragraph_Split_Policy>(out, call, context);
     }
     case Known_Content_Policy::no_invoke: {
         return consume_simply<Unprocessed_Content_Policy>(out, call, context);
@@ -139,14 +147,11 @@ Processing_Status Internal_Arg_Source_As_Text_Behavior::splice(
     Context& context
 ) const
 {
-    Value_Of_Type_Matcher value_matcher { &Type::block };
-    Group_Member_Matcher value_member { u8"value"sv, Optionality::mandatory, value_matcher };
-    Group_Member_Matcher* const parameters[] { &value_member };
-    Pack_Usual_Matcher args_matcher { parameters };
-    Group_Pack_Matcher group_matcher { args_matcher };
-    Call_Matcher call_matcher { group_matcher };
+    Value_Of_Type_Matcher value_matcher { Type::block };
+    Parameter value_param { u8"value"sv, Optionality::mandatory, value_matcher };
+    Parameter* const parameters[] { &value_param };
 
-    const auto match_status = call_matcher.match_call(call, context, make_fail_callback());
+    const auto match_status = match_call(parameters, call, context);
     if (match_status != Processing_Status::ok) {
         return status_is_error(match_status) ? try_generate_error(out, call, context, match_status)
                                              : match_status;

--- a/src/main/cpp/directives/reference.cpp
+++ b/src/main/cpp/directives/reference.cpp
@@ -118,13 +118,12 @@ Processing_Status
 Ref_Behavior::splice(Content_Policy& out, const Invocation& call, Context& context) const
 {
     Spliceable_To_String_Matcher to_matcher { context.get_transient_memory() };
-    Group_Member_Matcher to_member { u8"to"sv, Optionality::mandatory, to_matcher };
-    Group_Member_Matcher* const parameters[] { &to_member };
-    Pack_Usual_Matcher args_matcher { parameters };
-    Group_Pack_Matcher group_matcher { args_matcher };
-    Call_Matcher call_matcher { group_matcher };
+    Parameter to_param { u8"to"sv, Optionality::mandatory, to_matcher };
+    Block_Matcher content_matcher;
+    Parameter content_param { u8"content"sv, Optionality::optional, content_matcher };
+    Parameter* const parameters[] { &to_param, &content_param };
 
-    const auto match_status = call_matcher.match_call(call, context, make_fail_callback());
+    const auto match_status = match_call(parameters, call, context);
     if (match_status != Processing_Status::ok) {
         return status_is_error(match_status) ? try_generate_error(out, call, context, match_status)
                                              : match_status;
@@ -152,7 +151,7 @@ Ref_Behavior::splice(Content_Policy& out, const Invocation& call, Context& conte
             target_string,
         };
         reference_section(buffer, joined_char_sequence(section_name_parts));
-        if (call.has_empty_content()) {
+        if (!content_matcher.was_matched()) {
             writer.write_inner_html(u8'[');
             writer.write_inner_text(target_string);
             writer.write_inner_html(u8']');
@@ -168,7 +167,7 @@ Ref_Behavior::splice(Content_Policy& out, const Invocation& call, Context& conte
             .write_href(target_string)
             .end();
         auto status = Processing_Status::ok;
-        if (call.has_empty_content()) {
+        if (!content_matcher.was_matched()) {
             const std::u8string_view section_name_parts[] {
                 section_name::id_preview,
                 u8".",
@@ -178,7 +177,7 @@ Ref_Behavior::splice(Content_Policy& out, const Invocation& call, Context& conte
         }
         else {
             buffer.flush();
-            status = splice_all(out, call.get_content_span(), call.content_frame, context);
+            status = content_matcher.get().splice_block(out, context);
         }
         writer.close_tag(html_tag::a);
         buffer.flush();
@@ -187,13 +186,13 @@ Ref_Behavior::splice(Content_Policy& out, const Invocation& call, Context& conte
 
     COWEL_ASSERT(classification.type == Reference_Type::url);
 
-    if (!call.has_empty_content()) {
+    if (content_matcher.was_matched()) {
         writer
             .open_tag_with_attributes(html_tag::a) //
             .write_href(target_string)
             .end();
         buffer.flush();
-        const auto status = splice_all(out, call.get_content_span(), call.content_frame, context);
+        const auto status = content_matcher.get().splice_block(out, context);
         writer.close_tag(html_tag::a);
         buffer.flush();
         return status;

--- a/src/main/cpp/directives/str.cpp
+++ b/src/main/cpp/directives/str.cpp
@@ -127,13 +127,10 @@ Result<Big_Int, Processing_Status>
 Str_Length_Behavior::do_evaluate(const Invocation& call, Context& context) const
 {
     String_Matcher x_matcher { context.get_transient_memory() };
-    Group_Member_Matcher x_member { u8"x", Optionality::mandatory, x_matcher };
-    Group_Member_Matcher* matchers[] { &x_member };
-    Pack_Usual_Matcher args_matcher { matchers };
-    Group_Pack_Matcher group_matcher { args_matcher };
-    Call_Matcher call_matcher { group_matcher };
+    Parameter x_param { u8"x", Optionality::mandatory, x_matcher };
+    Parameter* const parameters[] { &x_param };
 
-    const auto args_status = call_matcher.match_call(call, context, make_fail_callback());
+    const auto args_status = match_call(parameters, call, context);
     if (args_status != Processing_Status::ok) {
         return args_status;
     }
@@ -174,13 +171,10 @@ Processing_Status Str_Transform_Behavior::do_evaluate(
 ) const
 {
     String_Matcher x_matcher { context.get_transient_memory() };
-    Group_Member_Matcher x_member { u8"x", Optionality::mandatory, x_matcher };
-    Group_Member_Matcher* matchers[] { &x_member };
-    Pack_Usual_Matcher args_matcher { matchers };
-    Group_Pack_Matcher group_matcher { args_matcher };
-    Call_Matcher call_matcher { group_matcher };
+    Parameter x_param { u8"x", Optionality::mandatory, x_matcher };
+    Parameter* const parameters[] { &x_param };
 
-    const auto args_status = call_matcher.match_call(call, context, make_fail_callback());
+    const auto args_status = match_call(parameters, call, context);
     if (args_status != Processing_Status::ok) {
         return args_status;
     }
@@ -220,15 +214,12 @@ Result<bool, Processing_Status>
 Str_Match_Behavior::do_evaluate(const Invocation& call, Context& context) const
 {
     String_Matcher text_matcher { context.get_transient_memory() };
-    Group_Member_Matcher text_member { u8"text", Optionality::mandatory, text_matcher };
-    Value_Of_Type_Matcher regex_matcher { &Type::regex };
-    Group_Member_Matcher regex_member { u8"regex", Optionality::mandatory, regex_matcher };
-    Group_Member_Matcher* const matchers[] { &text_member, &regex_member };
-    Pack_Usual_Matcher args_matcher { matchers };
-    Group_Pack_Matcher group_matcher { args_matcher };
-    Call_Matcher call_matcher { group_matcher };
+    Parameter text_param { u8"text", Optionality::mandatory, text_matcher };
+    Value_Of_Type_Matcher regex_matcher { Type::regex };
+    Parameter regex_param { u8"regex", Optionality::mandatory, regex_matcher };
+    Parameter* const parameters[] { &text_param, &regex_param };
 
-    const auto args_status = call_matcher.match_call(call, context, make_fail_callback());
+    const auto args_status = match_call(parameters, call, context);
     if (args_status != Processing_Status::ok) {
         return args_status;
     }
@@ -260,15 +251,12 @@ Str_Contains_Behavior::do_evaluate(const Invocation& call, Context& context) con
     static_assert(needle_type.is_canonical());
 
     String_Matcher text_matcher { context.get_transient_memory() };
-    Group_Member_Matcher text_member { u8"text", Optionality::mandatory, text_matcher };
-    Value_Of_Type_Matcher needle_matcher { &needle_type };
-    Group_Member_Matcher needle_member { u8"needle", Optionality::mandatory, needle_matcher };
-    Group_Member_Matcher* const matchers[] { &text_member, &needle_member };
-    Pack_Usual_Matcher args_matcher { matchers };
-    Group_Pack_Matcher group_matcher { args_matcher };
-    Call_Matcher call_matcher { group_matcher };
+    Parameter text_param { u8"text", Optionality::mandatory, text_matcher };
+    Value_Of_Type_Matcher needle_matcher { needle_type };
+    Parameter needle_param { u8"needle", Optionality::mandatory, needle_matcher };
+    Parameter* const parameters[] { &text_param, &needle_param };
 
-    const auto args_status = call_matcher.match_call(call, context, make_fail_callback());
+    const auto args_status = match_call(parameters, call, context);
     if (args_status != Processing_Status::ok) {
         return args_status;
     }
@@ -306,15 +294,12 @@ Str_Find_Behavior::evaluate(const Invocation& call, Context& context) const
     static_assert(needle_type.is_canonical());
 
     String_Matcher text_matcher { context.get_transient_memory() };
-    Group_Member_Matcher text_member { u8"text", Optionality::mandatory, text_matcher };
-    Value_Of_Type_Matcher needle_matcher { &needle_type };
-    Group_Member_Matcher needle_member { u8"needle", Optionality::mandatory, needle_matcher };
-    Group_Member_Matcher* const matchers[] { &text_member, &needle_member };
-    Pack_Usual_Matcher args_matcher { matchers };
-    Group_Pack_Matcher group_matcher { args_matcher };
-    Call_Matcher call_matcher { group_matcher };
+    Parameter text_param { u8"text", Optionality::mandatory, text_matcher };
+    Value_Of_Type_Matcher needle_matcher { needle_type };
+    Parameter needle_param { u8"needle", Optionality::mandatory, needle_matcher };
+    Parameter* const parameters[] { &text_param, &needle_param };
 
-    const auto args_status = call_matcher.match_call(call, context, make_fail_callback());
+    const auto args_status = match_call(parameters, call, context);
     if (args_status != Processing_Status::ok) {
         return args_status;
     }
@@ -368,17 +353,14 @@ Str_Replace_Behavior::evaluate(const Invocation& call, Context& context) const
     static_assert(needle_type.is_canonical());
 
     String_Matcher text_matcher { context.get_transient_memory() };
-    Group_Member_Matcher text_member { u8"text", Optionality::mandatory, text_matcher };
-    Value_Of_Type_Matcher needle_matcher { &needle_type };
-    Group_Member_Matcher needle_member { u8"needle", Optionality::mandatory, needle_matcher };
+    Parameter text_param { u8"text", Optionality::mandatory, text_matcher };
+    Value_Of_Type_Matcher needle_matcher { needle_type };
+    Parameter needle_param { u8"needle", Optionality::mandatory, needle_matcher };
     String_Matcher with_matcher { context.get_transient_memory() };
-    Group_Member_Matcher with_member { u8"with", Optionality::mandatory, with_matcher };
-    Group_Member_Matcher* const matchers[] { &text_member, &needle_member, &with_member };
-    Pack_Usual_Matcher args_matcher { matchers };
-    Group_Pack_Matcher group_matcher { args_matcher };
-    Call_Matcher call_matcher { group_matcher };
+    Parameter with_param { u8"with", Optionality::mandatory, with_matcher };
+    Parameter* const parameters[] { &text_param, &needle_param, &with_param };
 
-    const auto args_status = call_matcher.match_call(call, context, make_fail_callback());
+    const auto args_status = match_call(parameters, call, context);
     if (args_status != Processing_Status::ok) {
         return args_status;
     }
@@ -452,15 +434,12 @@ Result<Value, Processing_Status>
 Regex_Make_Behavior::evaluate(const Invocation& call, Context& context) const
 {
     String_Matcher pattern_matcher { context.get_transient_memory() };
-    Group_Member_Matcher pattern_member { u8"pattern", Optionality::mandatory, pattern_matcher };
+    Parameter pattern_param { u8"pattern", Optionality::mandatory, pattern_matcher };
     String_Matcher flags_matcher { context.get_transient_memory() };
-    Group_Member_Matcher flags_member { u8"flags", Optionality::optional, flags_matcher };
-    Group_Member_Matcher* const matchers[] { &pattern_member, &flags_member };
-    Pack_Usual_Matcher args_matcher { matchers };
-    Group_Pack_Matcher group_matcher { args_matcher };
-    Call_Matcher call_matcher { group_matcher };
+    Parameter flags_param { u8"flags", Optionality::optional, flags_matcher };
+    Parameter* const parameters[] { &pattern_param, &flags_param };
 
-    const auto args_status = call_matcher.match_call(call, context, make_fail_callback());
+    const auto args_status = match_call(parameters, call, context);
     if (args_status != Processing_Status::ok) {
         return args_status;
     }

--- a/src/main/cpp/directives/syntax_highlight.cpp
+++ b/src/main/cpp/directives/syntax_highlight.cpp
@@ -35,17 +35,21 @@ Processing_Status
 Code_Behavior::splice(Content_Policy& out, const Invocation& call, Context& context) const
 {
     Spliceable_To_String_Matcher lang_string_matcher { context.get_transient_memory() };
-    Group_Member_Matcher lang_member { u8"lang"sv, Optionality::mandatory, lang_string_matcher };
+    Parameter lang_param { u8"lang"sv, Optionality::mandatory, lang_string_matcher };
     Boolean_Matcher nested_boolean;
-    Group_Member_Matcher nested_member { u8"nested"sv, Optionality::optional, nested_boolean };
+    Parameter nested_param { u8"nested"sv, Optionality::optional, nested_boolean };
     Boolean_Matcher borders_boolean;
-    Group_Member_Matcher borders_member { u8"borders"sv, Optionality::optional, borders_boolean };
-    Group_Member_Matcher* parameters[] { &lang_member, &nested_member, &borders_member };
-    Pack_Usual_Matcher args_matcher { parameters };
-    Group_Pack_Matcher group_matcher { args_matcher };
-    Call_Matcher call_matcher { group_matcher };
+    Parameter borders_param { u8"borders"sv, Optionality::optional, borders_boolean };
+    Block_Matcher content_matcher;
+    Parameter content_param { u8"content"sv, Optionality::mandatory, content_matcher };
+    Parameter* const parameters[] {
+        &lang_param,
+        &nested_param,
+        &borders_param,
+        &content_param,
+    };
 
-    const auto match_status = call_matcher.match_call(call, context, make_fail_callback());
+    const auto match_status = match_call(parameters, call, context);
     if (match_status != Processing_Status::ok) {
         return status_is_error(match_status) ? try_generate_error(out, call, context, match_status)
                                              : match_status;
@@ -57,8 +61,7 @@ Code_Behavior::splice(Content_Policy& out, const Invocation& call, Context& cont
     // Note that for consistent side effects,
     // we still process all the arguments above.
     if (out.get_language() == Output_Language::text) {
-        const Processing_Status text_status
-            = splice_all(out, call.get_content_span(), call.content_frame, context);
+        const Processing_Status text_status = content_matcher.get().splice_block(out, context);
         return text_status;
     }
 
@@ -88,8 +91,7 @@ Code_Behavior::splice(Content_Policy& out, const Invocation& call, Context& cont
 
     Syntax_Highlight_Policy highlight_policy //
         { context.get_transient_memory() };
-    const auto highlight_status
-        = splice_all(highlight_policy, call.get_content_span(), call.content_frame, context);
+    const auto highlight_status = content_matcher.get().splice_block(highlight_policy, context);
 
     const Result<void, Syntax_Highlight_Error> result = [&] {
         if (!should_trim) {
@@ -130,13 +132,12 @@ Processing_Status
 Highlight_As_Behavior::splice(Content_Policy& out, const Invocation& call, Context& context) const
 {
     Spliceable_To_String_Matcher name_string { context.get_transient_memory() };
-    Group_Member_Matcher name_member { u8"name"sv, Optionality::mandatory, name_string };
-    Group_Member_Matcher* parameters[] { &name_member };
-    Pack_Usual_Matcher args_matcher { parameters };
-    Group_Pack_Matcher group_matcher { args_matcher };
-    Call_Matcher call_matcher { group_matcher };
+    Parameter name_param { u8"name"sv, Optionality::mandatory, name_string };
+    Block_Matcher content_matcher;
+    Parameter content_param { u8"content"sv, Optionality::mandatory, content_matcher };
+    Parameter* const parameters[] { &name_param, &content_param };
 
-    const auto match_status = call_matcher.match_call(call, context, make_fail_callback());
+    const auto match_status = match_call(parameters, call, context);
     if (match_status != Processing_Status::ok) {
         return status_is_error(match_status) ? try_generate_error(out, call, context, match_status)
                                              : match_status;
@@ -162,7 +163,7 @@ Highlight_As_Behavior::splice(Content_Policy& out, const Invocation& call, Conte
 
     // We do the same special casing as for \code (see above for explanation).
     if (out.get_language() == Output_Language::text) {
-        return splice_all(out, call.get_content_span(), call.content_frame, context);
+        return content_matcher.get().splice_block(out, context);
     }
 
     HTML_Content_Policy policy = ensure_html_policy(out);
@@ -173,8 +174,7 @@ Highlight_As_Behavior::splice(Content_Policy& out, const Invocation& call, Conte
         .write_attribute(html_attr::data_h, short_name)
         .end();
     buffer.flush();
-    const Processing_Status result
-        = splice_all(policy, call.get_content_span(), call.content_frame, context);
+    const Processing_Status result = content_matcher.get().splice_block(policy, context);
     if (status_is_break(result)) {
         return result;
     }

--- a/src/main/cpp/directives/variables.cpp
+++ b/src/main/cpp/directives/variables.cpp
@@ -141,40 +141,16 @@ static_assert(variable_type.is_canonical());
 Result<bool, Processing_Status>
 Logical_Not_Behavior::do_evaluate(const Invocation& call, Context& context) const
 {
-    Group_Pack_Value_Matcher group_matcher { context.get_transient_memory() };
-    Call_Matcher call_matcher { group_matcher };
+    Boolean_Matcher x_matcher;
+    Parameter x_param { u8"x"sv, Optionality::mandatory, x_matcher };
+    Parameter* const parameters[] { &x_param };
 
-    const auto match_status = call_matcher.match_call(call, context, make_fail_callback());
+    const auto match_status = match_call(parameters, call, context);
     if (match_status != Processing_Status::ok) {
         return match_status;
     }
 
-    if (group_matcher.get_values().size() != 1) {
-        context.try_error(
-            diagnostic::type_mismatch, call.get_arguments_source_span(),
-            u8"Logical NOT is unary and requires exactly one argument"sv
-        );
-        return Processing_Status::error;
-    }
-
-    const auto& argument = group_matcher.get_values().front();
-
-    if (argument.value.get_type() != Type::boolean) {
-        context.try_error(
-            diagnostic::type_mismatch, argument.location,
-            joined_char_sequence(
-                {
-                    u8"Expected a value of type "sv,
-                    Type::boolean.get_display_name(),
-                    u8", but got "sv,
-                    argument.value.get_type().get_display_name(),
-                    u8".",
-                }
-            )
-        );
-    }
-
-    return !argument.value.as_boolean();
+    return !x_matcher.get();
 }
 
 namespace {
@@ -203,52 +179,27 @@ struct Logical_Expression_Evaluator {
 
     [[nodiscard]]
     Result<bool, Processing_Status>
-    operator()(std::span<const ast::Group_Member> members, Frame_Index frame) const
+    operator()(std::span<const Argument> arguments, Frame_Index frame) const
     {
         const bool neutral_element = kind == Logical_Expression_Kind::logical_and;
         const bool terminator = !neutral_element;
 
-        for (const ast::Group_Member& member : members) {
-            switch (member.get_kind()) {
-            case ast::Member_Kind::named: {
-                return Processing_Status::error;
+        for (const Argument& member : arguments) {
+            COWEL_ASSERT(member.is_positional());
+            const Type& static_type = member.get_static_type(context);
+            if (!static_type.analytically_convertible_to(Type::boolean)) {
+                return type_error(static_type, member.get_value_location());
             }
-            case ast::Member_Kind::ellipsis: {
-                const Stack_Frame& ellipsis_frame = context.get_call_stack()[frame];
-                Result<bool, Processing_Status> maybe_result = (*this)(
-                    ellipsis_frame.invocation.get_arguments_span(),
-                    ellipsis_frame.invocation.content_frame
-                );
-                if (!maybe_result) {
-                    return maybe_result;
-                }
-                if (*maybe_result == terminator) {
-                    return *maybe_result;
-                }
-                continue;
+            const Result<Value, Processing_Status> member_result = member.evaluate(frame, context);
+            if (!member_result) {
+                return member_result.error();
             }
-            case ast::Member_Kind::positional: {
-                const ast::Expression& member_value = member.get_value();
-                const std::optional<Type> static_type
-                    = cowel::get_static_type(member_value, context);
-                if (static_type && *static_type != Type::boolean) {
-                    return type_error(*static_type, member_value.get_source_span());
-                }
-                const Result<Value, Processing_Status> member_result
-                    = evaluate_expression(member_value, frame, context);
-                if (!member_result) {
-                    return member_result.error();
-                }
-                if (!member_result->is_bool()) {
-                    return type_error(member_result->get_type(), member_value.get_source_span());
-                }
-                if (member_result->as_boolean() == terminator) {
-                    return terminator;
-                }
-                continue;
+            if (!member_result->is_bool()) {
+                return type_error(member_result->get_type(), member.get_value_location());
             }
+            if (member_result->as_boolean() == terminator) {
+                return terminator;
             }
-            COWEL_ASSERT_UNREACHABLE(u8"Invalid member kind.");
         }
         return neutral_element;
     }
@@ -259,16 +210,17 @@ struct Logical_Expression_Evaluator {
 Result<bool, Processing_Status>
 Logical_Expression_Behavior::do_evaluate(const Invocation& call, Context& context) const
 {
-    Group_Pack_Lazy_Any_Matcher group_matcher;
-    Call_Matcher call_matcher { group_matcher };
+    Pack_Lazy_Any_Matcher args_matcher;
+    Parameter args_param { u8"args"sv, Optionality::mandatory, args_matcher };
+    Parameter* const parameters[] { &args_param };
 
-    const auto match_status = call_matcher.match_call(call, context, make_fail_callback());
+    const auto match_status = match_call(parameters, call, context);
     if (match_status != Processing_Status::ok) {
         return match_status;
     }
 
     const Logical_Expression_Evaluator evaluator { m_expression_kind, context };
-    return evaluator(group_matcher.get().get_members(), call.content_frame);
+    return evaluator(args_matcher.get(), call.content_frame);
 }
 
 Result<bool, Processing_Status>
@@ -283,20 +235,17 @@ Comparison_Expression_Behavior::do_evaluate(const Invocation& call, Context& con
     static constexpr Type relation_comparable_types[] { Type::integer, Type::floating, Type::str };
     static constexpr auto relation_comparable = Type::union_of(relation_comparable_types);
     static_assert(relation_comparable.is_canonical());
-    const auto* parameter_type = m_expression_kind <= Comparison_Expression_Kind::ne
-        ? &equality_comparable
-        : &relation_comparable;
+    const auto& parameter_type = m_expression_kind <= Comparison_Expression_Kind::ne
+        ? equality_comparable
+        : relation_comparable;
 
     Value_Of_Type_Matcher x_value { parameter_type };
-    Group_Member_Matcher x_member { u8"x"sv, Optionality::mandatory, x_value };
+    Parameter x_param { u8"x"sv, Optionality::mandatory, x_value };
     Value_Of_Type_Matcher y_value { parameter_type };
-    Group_Member_Matcher y_member { u8"y"sv, Optionality::mandatory, y_value };
-    Group_Member_Matcher* const matchers[] { &x_member, &y_member };
-    Pack_Usual_Matcher args_matcher { matchers };
-    Group_Pack_Matcher group_matcher { args_matcher };
-    Call_Matcher call_matcher { group_matcher };
+    Parameter y_param { u8"y"sv, Optionality::mandatory, y_value };
+    Parameter* const parameters[] { &x_param, &y_param };
 
-    const auto match_status = call_matcher.match_call(call, context, make_fail_callback());
+    const auto match_status = match_call(parameters, call, context);
     if (match_status != Processing_Status::ok) {
         return match_status;
     }
@@ -342,16 +291,13 @@ Internal_Eq_Behavior::do_evaluate(const Invocation& call, Context& context) cons
     static constexpr auto equality_comparable = Type::union_of(equality_comparable_types);
     static_assert(equality_comparable.is_canonical());
 
-    Value_Of_Type_Matcher x_value { &equality_comparable };
-    Group_Member_Matcher x_member { u8"x"sv, Optionality::mandatory, x_value };
-    Value_Of_Type_Matcher y_value { &equality_comparable };
-    Group_Member_Matcher y_member { u8"y"sv, Optionality::mandatory, y_value };
-    Group_Member_Matcher* const matchers[] { &x_member, &y_member };
-    Pack_Usual_Matcher args_matcher { matchers };
-    Group_Pack_Matcher group_matcher { args_matcher };
-    Call_Matcher call_matcher { group_matcher };
+    Value_Of_Type_Matcher x_value { equality_comparable };
+    Parameter x_param { u8"x"sv, Optionality::mandatory, x_value };
+    Value_Of_Type_Matcher y_value { equality_comparable };
+    Parameter y_param { u8"y"sv, Optionality::mandatory, y_value };
+    Parameter* const parameters[] { &x_param, &y_param };
 
-    const auto match_status = call_matcher.match_call(call, context, make_fail_callback());
+    const auto match_status = match_call(parameters, call, context);
     if (match_status != Processing_Status::ok) {
         return match_status;
     }
@@ -383,47 +329,22 @@ Internal_Eq_Behavior::do_evaluate(const Invocation& call, Context& context) cons
 Result<Value, Processing_Status>
 Unary_Numeric_Expression_Behavior::evaluate(const Invocation& call, Context& context) const
 {
-    Group_Pack_Value_Matcher group_matcher { context.get_transient_memory() };
-    Call_Matcher call_matcher { group_matcher };
+    Value_Of_Type_Matcher x_matcher { *m_type };
+    Parameter x_param { u8"x"sv, Optionality::mandatory, x_matcher };
+    Parameter* const parameters[] { &x_param };
 
-    const auto match_status = call_matcher.match_call(call, context, make_fail_callback());
+    const auto match_status = match_call(parameters, call, context);
     if (match_status != Processing_Status::ok) {
         return match_status;
     }
 
-    if (group_matcher.get_values().size() != 1) {
-        context.try_error(
-            diagnostic::type_mismatch, call.get_arguments_source_span(),
-            u8"Unary operation requires exactly one argument"sv
-        );
-        return Processing_Status::error;
-    }
-
-    const auto& first_value = group_matcher.get_values().front().value;
-    const auto& first_type = first_value.get_type();
-
-    if (!first_type.analytically_convertible_to(*m_type)) {
-        context.try_error(
-            diagnostic::type_mismatch, group_matcher.get_values().front().location,
-            joined_char_sequence(
-                {
-                    u8"Expected a value of type "sv,
-                    m_type->get_display_name(),
-                    u8", but got "sv,
-                    first_type.get_display_name(),
-                    u8".",
-                }
-            )
-        );
-        return Processing_Status::error;
-    }
-
-    switch (first_type.get_kind()) {
+    const Value& x = x_matcher.get();
+    switch (x.get_type_kind()) {
     case Type_Kind::integer: {
-        return Value::integer(operate_unary(m_expression_kind, first_value.as_integer()));
+        return Value::integer(operate_unary(m_expression_kind, x.as_integer()));
     }
     case Type_Kind::floating: {
-        return Value::floating(operate_unary(m_expression_kind, first_value.as_float()));
+        return Value::floating(operate_unary(m_expression_kind, x.as_float()));
     }
     default: break;
     }
@@ -433,67 +354,42 @@ Unary_Numeric_Expression_Behavior::evaluate(const Invocation& call, Context& con
 Result<Big_Int, Processing_Status>
 Integer_Division_Expression_Behavior::do_evaluate(const Invocation& call, Context& context) const
 {
-    Group_Pack_Value_Matcher group_matcher { context.get_transient_memory() };
-    Call_Matcher call_matcher { group_matcher };
+    Integer_Matcher x_matcher;
+    Parameter x_param { u8"x"sv, Optionality::mandatory, x_matcher };
+    Integer_Matcher y_matcher;
+    Parameter y_param { u8"y"sv, Optionality::mandatory, y_matcher };
+    Parameter* const parameters[] { &x_param, &y_param };
 
-    const auto match_status = call_matcher.match_call(call, context, make_fail_callback());
+    const auto match_status = match_call(parameters, call, context);
     if (match_status != Processing_Status::ok) {
         return match_status;
     }
 
-    bool type_check_ok = true;
-    if (group_matcher.get_values().size() != 2) {
+    const Big_Int& x = x_matcher.get();
+    const Big_Int& y = y_matcher.get();
+
+    if (y.is_zero()) {
         context.try_error(
-            diagnostic::type_mismatch, call.get_arguments_source_span(),
-            u8"Binary operation requires two arguments."sv
+            diagnostic::arithmetic_div_by_zero, y_matcher.get_location(), u8"Division by zero."sv
         );
-        type_check_ok = false;
-    }
-
-    for (const auto& [value, location] : group_matcher.get_values()) {
-        if (value.get_type() != Type::integer) {
-            context.try_error(
-                diagnostic::type_mismatch, location,
-                joined_char_sequence(
-                    {
-                        u8"Expected a value of type "sv,
-                        Type::integer.get_display_name(),
-                        u8", but got "sv,
-                        value.get_type().get_display_name(),
-                        u8".",
-                    }
-                )
-            );
-            type_check_ok = false;
-        }
-    }
-    if (!type_check_ok) {
         return Processing_Status::error;
     }
-
-    const auto& x_value = group_matcher.get_values()[0].value;
-    const auto& [y_value, y_location] = group_matcher.get_values()[1];
-
-    if (y_value.as_integer().is_zero()) {
-        context.try_error(diagnostic::arithmetic_div_by_zero, y_location, u8"Division by zero."sv);
-        return Processing_Status::error;
-    }
-    Big_Int result = operate_binary(m_expression_kind, x_value.as_integer(), y_value.as_integer());
-    return result;
+    return operate_binary(m_expression_kind, x, y);
 }
 
 Result<Value, Processing_Status>
 N_Ary_Numeric_Expression_Behavior::evaluate(const Invocation& call, Context& context) const
 {
-    Group_Pack_Value_Matcher group_matcher { context.get_transient_memory() };
-    Call_Matcher call_matcher { group_matcher };
+    Pack_Of_Type_Matcher args_matcher { Type::pack_of(&Type::any) };
+    Parameter args_param { u8"args"sv, Optionality::mandatory, args_matcher };
+    Parameter* const parameters[] { &args_param };
 
-    const auto match_status = call_matcher.match_call(call, context, make_fail_callback());
+    const auto match_status = match_call(parameters, call, context);
     if (match_status != Processing_Status::ok) {
         return match_status;
     }
 
-    if (group_matcher.get_values().empty()) {
+    if (args_matcher.get().empty()) {
         context.try_error(
             diagnostic::type_mismatch, call.get_arguments_source_span(),
             u8"Cannot perform arithmetic with empty pack of arguments."sv
@@ -501,11 +397,11 @@ N_Ary_Numeric_Expression_Behavior::evaluate(const Invocation& call, Context& con
         return Processing_Status::error;
     }
 
-    const auto& first_value = group_matcher.get_values().front().value;
+    const auto& first_value = args_matcher.get().front().value;
     const auto& first_type = first_value.get_type();
 
     bool type_check_ok = true;
-    for (const auto& [value, location] : group_matcher.get_values()) {
+    for (const auto& [value, location] : args_matcher.get()) {
         if (m_expression_kind == N_Ary_Numeric_Expression_Kind::div) {
             if (value.get_type() != Type::floating) {
                 context.try_error(
@@ -558,9 +454,9 @@ N_Ary_Numeric_Expression_Behavior::evaluate(const Invocation& call, Context& con
         return Processing_Status::error;
     }
 
-    COWEL_ASSERT(!group_matcher.get_values().empty());
+    COWEL_ASSERT(!args_matcher.get().empty());
 
-    const auto values_without_first = group_matcher.get_values() | std::views::drop(1);
+    const auto values_without_first = args_matcher.get() | std::views::drop(1);
 
     switch (first_type.get_kind()) {
     case Type_Kind::integer: {
@@ -605,25 +501,22 @@ To_Str_Behavior::evaluate(const Invocation& call, Context& context) const
         u8"splice"sv,
     };
 
-    Value_Of_Type_Matcher x_matcher { &to_str_type };
-    Group_Member_Matcher x_member { u8"x"sv, Optionality::mandatory, x_matcher };
+    Value_Of_Type_Matcher x_matcher { to_str_type };
+    Parameter x_param { u8"x"sv, Optionality::mandatory, x_matcher };
     Integer_Matcher base_matcher;
-    Group_Member_Matcher base_member { u8"base"sv, Optionality::optional, base_matcher };
+    Parameter base_param { u8"base"sv, Optionality::optional, base_matcher };
     Integer_Matcher zpad_matcher;
-    Group_Member_Matcher zpad_member { u8"zpad"sv, Optionality::optional, zpad_matcher };
+    Parameter zpad_param { u8"zpad"sv, Optionality::optional, zpad_matcher };
     Sorted_Options_Matcher format_matcher { format_options };
-    Group_Member_Matcher format_member { u8"format"sv, Optionality::optional, format_matcher };
-    Group_Member_Matcher* const parameters[] {
-        &x_member,
-        &base_member,
-        &zpad_member,
-        &format_member,
+    Parameter format_param { u8"format"sv, Optionality::optional, format_matcher };
+    Parameter* const parameters[] {
+        &x_param,
+        &base_param,
+        &zpad_param,
+        &format_param,
     };
-    Pack_Usual_Matcher args_matcher { parameters };
-    Group_Pack_Matcher group_matcher { args_matcher };
-    Call_Matcher call_matcher { group_matcher };
 
-    const auto match_status = call_matcher.match_call(call, context, make_fail_callback());
+    const auto match_status = match_call(parameters, call, context);
     if (match_status != Processing_Status::ok) {
         return match_status;
     }
@@ -789,13 +682,10 @@ Result<Float, Processing_Status>
 Reinterpret_As_Float_Behavior::do_evaluate(const Invocation& call, Context& context) const
 {
     Integer_Matcher x_matcher {};
-    Group_Member_Matcher to_member { u8"x"sv, Optionality::mandatory, x_matcher };
-    Group_Member_Matcher* const parameters[] { &to_member };
-    Pack_Usual_Matcher args_matcher { parameters };
-    Group_Pack_Matcher group_matcher { args_matcher };
-    Call_Matcher call_matcher { group_matcher };
+    Parameter to_param { u8"x"sv, Optionality::mandatory, x_matcher };
+    Parameter* const parameters[] { &to_param };
 
-    const auto match_status = call_matcher.match_call(call, context, make_fail_callback());
+    const auto match_status = match_call(parameters, call, context);
     if (match_status != Processing_Status::ok) {
         return match_status;
     }
@@ -843,13 +733,10 @@ Result<Big_Int, Processing_Status>
 Reinterpret_As_Int_Behavior::do_evaluate(const Invocation& call, Context& context) const
 {
     Float_Matcher x_matcher {};
-    Group_Member_Matcher x_member { u8"x"sv, Optionality::mandatory, x_matcher };
-    Group_Member_Matcher* const parameters[] { &x_member };
-    Pack_Usual_Matcher args_matcher { parameters };
-    Group_Pack_Matcher group_matcher { args_matcher };
-    Call_Matcher call_matcher { group_matcher };
+    Parameter x_param { u8"x"sv, Optionality::mandatory, x_matcher };
+    Parameter* const parameters[] { &x_param };
 
-    const auto match_status = call_matcher.match_call(call, context, make_fail_callback());
+    const auto match_status = match_call(parameters, call, context);
     if (match_status != Processing_Status::ok) {
         return match_status;
     }
@@ -862,13 +749,10 @@ Reinterpret_As_Int_Behavior::do_evaluate(const Invocation& call, Context& contex
 Processing_Status Var_Delete_Behavior::do_evaluate(const Invocation& call, Context& context) const
 {
     String_Matcher name_matcher { context.get_transient_memory() };
-    Group_Member_Matcher name_member { u8"name"sv, Optionality::mandatory, name_matcher };
-    Group_Member_Matcher* const parameters[] { &name_member };
-    Pack_Usual_Matcher args_matcher { parameters };
-    Group_Pack_Matcher group_matcher { args_matcher };
-    Call_Matcher call_matcher { group_matcher };
+    Parameter name_param { u8"name"sv, Optionality::mandatory, name_matcher };
+    Parameter* const parameters[] { &name_param };
 
-    const auto status = call_matcher.match_call(call, context, make_fail_callback());
+    const auto status = match_call(parameters, call, context);
     if (status != Processing_Status::ok) {
         return status;
     }
@@ -897,13 +781,10 @@ Result<bool, Processing_Status>
 Var_Exists_Behavior::do_evaluate(const Invocation& call, Context& context) const
 {
     String_Matcher name_matcher { context.get_transient_memory() };
-    Group_Member_Matcher name_member { u8"name"sv, Optionality::mandatory, name_matcher };
-    Group_Member_Matcher* const parameters[] { &name_member };
-    Pack_Usual_Matcher args_matcher { parameters };
-    Group_Pack_Matcher group_matcher { args_matcher };
-    Call_Matcher call_matcher { group_matcher };
+    Parameter name_param { u8"name"sv, Optionality::mandatory, name_matcher };
+    Parameter* const parameters[] { &name_param };
 
-    const auto status = call_matcher.match_call(call, context, make_fail_callback());
+    const auto status = match_call(parameters, call, context);
     if (status != Processing_Status::ok) {
         return status;
     }
@@ -915,13 +796,10 @@ Result<Value, Processing_Status>
 Var_Get_Behavior::evaluate(const Invocation& call, Context& context) const
 {
     String_Matcher name_matcher { context.get_transient_memory() };
-    Group_Member_Matcher name_member { u8"name"sv, Optionality::mandatory, name_matcher };
-    Group_Member_Matcher* const parameters[] { &name_member };
-    Pack_Usual_Matcher args_matcher { parameters };
-    Group_Pack_Matcher group_matcher { args_matcher };
-    Call_Matcher call_matcher { group_matcher };
+    Parameter name_param { u8"name"sv, Optionality::mandatory, name_matcher };
+    Parameter* const parameters[] { &name_param };
 
-    const auto status = call_matcher.match_call(call, context, make_fail_callback());
+    const auto status = match_call(parameters, call, context);
     if (status != Processing_Status::ok) {
         return status;
     }
@@ -946,15 +824,12 @@ Var_Get_Behavior::evaluate(const Invocation& call, Context& context) const
 Processing_Status Var_Let_Behavior::do_evaluate(const Invocation& call, Context& context) const
 {
     String_Matcher name_matcher { context.get_transient_memory() };
-    Group_Member_Matcher name_member { u8"name"sv, Optionality::mandatory, name_matcher };
-    Value_Of_Type_Matcher value_matcher { &variable_type };
-    Group_Member_Matcher value_member { u8"value"sv, Optionality::optional, value_matcher };
-    Group_Member_Matcher* const parameters[] { &name_member, &value_member };
-    Pack_Usual_Matcher args_matcher { parameters };
-    Group_Pack_Matcher group_matcher { args_matcher };
-    Call_Matcher call_matcher { group_matcher };
+    Parameter name_param { u8"name"sv, Optionality::mandatory, name_matcher };
+    Value_Of_Type_Matcher value_matcher { variable_type };
+    Parameter value_param { u8"value"sv, Optionality::optional, value_matcher };
+    Parameter* const parameters[] { &name_param, &value_param };
 
-    const auto status = call_matcher.match_call(call, context, make_fail_callback());
+    const auto status = match_call(parameters, call, context);
     if (status != Processing_Status::ok) {
         return status;
     }
@@ -985,15 +860,12 @@ Processing_Status Var_Let_Behavior::do_evaluate(const Invocation& call, Context&
 Processing_Status Var_Set_Behavior::do_evaluate(const Invocation& call, Context& context) const
 {
     String_Matcher name_matcher { context.get_transient_memory() };
-    Group_Member_Matcher name_member { u8"name"sv, Optionality::mandatory, name_matcher };
-    Value_Of_Type_Matcher value_matcher { &variable_type };
-    Group_Member_Matcher value_member { u8"value"sv, Optionality::mandatory, value_matcher };
-    Group_Member_Matcher* const parameters[] { &name_member, &value_member };
-    Pack_Usual_Matcher args_matcher { parameters };
-    Group_Pack_Matcher group_matcher { args_matcher };
-    Call_Matcher call_matcher { group_matcher };
+    Parameter name_param { u8"name"sv, Optionality::mandatory, name_matcher };
+    Value_Of_Type_Matcher value_matcher { variable_type };
+    Parameter value_param { u8"value"sv, Optionality::mandatory, value_matcher };
+    Parameter* const parameters[] { &name_param, &value_param };
 
-    const auto status = call_matcher.match_call(call, context, make_fail_callback());
+    const auto status = match_call(parameters, call, context);
     if (status != Processing_Status::ok) {
         return status;
     }

--- a/src/main/cpp/directives/wg21.cpp
+++ b/src/main/cpp/directives/wg21.cpp
@@ -8,7 +8,6 @@
 #include "cowel/policy/content_policy.hpp"
 #include "cowel/policy/html.hpp"
 
-#include "cowel/ast.hpp"
 #include "cowel/builtin_directive_set.hpp"
 #include "cowel/content_status.hpp"
 #include "cowel/context.hpp"
@@ -22,14 +21,13 @@ namespace cowel {
 Processing_Status
 WG21_Head_Behavior::splice(Content_Policy& out, const Invocation& call, Context& context) const
 {
-    Lazy_Value_Of_Type_Matcher title_markup { &Type::block };
-    Group_Member_Matcher title_member { u8"title"sv, Optionality::mandatory, title_markup };
-    Group_Member_Matcher* const parameters[] { &title_member };
-    Pack_Usual_Matcher args_matcher { parameters };
-    Group_Pack_Matcher group_matcher { args_matcher };
-    Call_Matcher call_matcher { group_matcher };
+    Lazy_Value_Of_Type_Matcher title_markup { Type::block };
+    Parameter title_param { u8"title"sv, Optionality::mandatory, title_markup };
+    Block_Matcher content_matcher;
+    Parameter content_param { u8"content"sv, Optionality::mandatory, content_matcher };
+    Parameter* const parameters[] { &title_param, &content_param };
 
-    const auto match_status = call_matcher.match_call(call, context, make_fail_callback());
+    const auto match_status = match_call(parameters, call, context);
     if (match_status != Processing_Status::ok) {
         return match_status;
     }
@@ -43,14 +41,12 @@ WG21_Head_Behavior::splice(Content_Policy& out, const Invocation& call, Context&
         .write_class(u8"wg21-head"sv)
         .end();
 
-    const std::span<const ast::Markup_Element> title_elements
-        = title_markup.get().as_primary().get_elements();
+    const Argument& title_arg = title_markup.get();
     {
         // FIXME: multiple evaluations of title input
         std::pmr::vector<char8_t> title_plaintext { context.get_transient_memory() };
-        const auto status = splice_to_plaintext(
-            title_plaintext, title_elements, title_markup.get_frame(), context
-        );
+        const auto status
+            = title_arg.splice_to_plaintext(title_plaintext, title_markup.get_frame(), context);
         if (status != Processing_Status::ok) {
             writer.close_tag(html_tag::div);
             return status;
@@ -70,8 +66,7 @@ WG21_Head_Behavior::splice(Content_Policy& out, const Invocation& call, Context&
     writer.open_tag(html_tag::h1);
 
     HTML_Content_Policy html_policy { buffer };
-    const auto title_status
-        = splice_all(html_policy, title_elements, title_markup.get_frame(), context);
+    const auto title_status = title_arg.splice(html_policy, title_markup.get_frame(), context);
 
     writer.close_tag(html_tag::h1);
     if (status_is_break(title_status)) {
@@ -79,8 +74,7 @@ WG21_Head_Behavior::splice(Content_Policy& out, const Invocation& call, Context&
     }
 
     writer.write_inner_html(u8'\n');
-    const auto status
-        = splice_all(html_policy, call.get_content_span(), call.content_frame, context);
+    const auto status = content_matcher.get().splice_block(html_policy, context);
     writer.close_tag(html_tag::div);
 
     return status;

--- a/src/main/cpp/parameters.cpp
+++ b/src/main/cpp/parameters.cpp
@@ -4,26 +4,108 @@
 
 #include "cowel/context.hpp"
 #include "cowel/parameters.hpp"
+#include "cowel/util/small_vector.hpp"
 
 namespace cowel {
 
+Result<Value, Processing_Status> Argument::group_member_evaluate(
+    const void* const ast_node, //
+    const Frame_Index frame,
+    Context& context
+)
+{
+    return evaluate_expression(
+        static_cast<const ast::Group_Member*>(ast_node)->get_value(), frame, context
+    );
+}
+Processing_Status Argument::group_member_splice(
+    const void* const ast_node, //
+    Content_Policy& out,
+    const Frame_Index frame,
+    Context& context
+)
+{
+    return splice_expression(
+        out, static_cast<const ast::Group_Member*>(ast_node)->get_value(), frame, context
+    );
+}
+Processing_Status Argument::group_member_splice_to_plaintext(
+    const void* ast_node,
+    std::pmr::vector<char8_t>& out,
+    Frame_Index frame,
+    Context& context
+)
+{
+    return splice_expression_to_plaintext(
+        out, static_cast<const ast::Group_Member*>(ast_node)->get_value(), frame, context
+    );
+}
+const File_Source_Span& Argument::group_member_get_source_span(const void* const ast_node) noexcept
+{
+    return static_cast<const ast::Group_Member*>(ast_node)->get_source_span();
+}
+const Type&
+Argument::group_member_get_static_type(const void* const ast_node, Context& context) noexcept
+{
+    return cowel::get_static_type(
+        static_cast<const ast::Group_Member*>(ast_node)->get_value(), context
+    );
+}
+
+Result<Value, Processing_Status> Argument::primary_evaluate(
+    const void* const ast_node, //
+    const Frame_Index frame,
+    Context& context
+)
+{
+    return cowel::evaluate(*static_cast<const ast::Primary*>(ast_node), frame, context);
+}
+Processing_Status Argument::primary_splice(
+    const void* const ast_node, //
+    Content_Policy& out,
+    const Frame_Index frame,
+    Context& context
+)
+{
+    return cowel::splice_primary(out, *static_cast<const ast::Primary*>(ast_node), frame, context);
+}
+Processing_Status Argument::primary_splice_to_plaintext(
+    const void* ast_node,
+    std::pmr::vector<char8_t>& out,
+    Frame_Index frame,
+    Context& context
+)
+{
+    return splice_expression_to_plaintext(
+        out, *static_cast<const ast::Primary*>(ast_node), frame, context
+    );
+}
+const File_Source_Span& Argument::primary_get_source_span(const void* ast_node) noexcept
+{
+    return static_cast<const ast::Primary*>(ast_node)->get_source_span();
+}
+const Type& Argument::primary_get_static_type(const void* const ast_node, Context&) noexcept
+{
+    return get_type(*static_cast<const ast::Primary*>(ast_node));
+}
+
 Processing_Status Lazy_Value_Of_Type_Matcher::match_value(
-    const ast::Expression& argument,
+    const Argument& argument,
     Frame_Index frame,
     Context& context,
     const Match_Fail_Options& on_fail
 )
 {
-    const Type& actual_type = get_static_type(argument, context);
+    const Type& actual_type = argument.get_static_type(context);
     COWEL_DEBUG_ASSERT(actual_type.is_canonical());
 
-    if (actual_type != Type::any && !actual_type.analytically_convertible_to(*m_expected_type)) {
+    if (actual_type != Type::any && !actual_type.analytically_convertible_to(get_type())) {
         on_fail.emit(
-            argument.get_source_span(),
+            argument.get_value_location(),
             joined_char_sequence(
                 {
                     u8"Expected a value of type "sv,
-                    m_expected_type->get_display_name(),
+                    get_type().get_display_name(),
                     u8", but got "sv,
                     actual_type.get_display_name(),
                     u8".",
@@ -33,31 +115,29 @@ Processing_Status Lazy_Value_Of_Type_Matcher::match_value(
         );
         return on_fail.status;
     }
-    m_markup = &argument;
+    m_value = { argument, argument.get_location() };
     m_markup_frame = frame;
     return Processing_Status::ok;
 }
 
 Processing_Status Value_Of_Type_Matcher::match_value(
-    const ast::Expression& argument,
+    const Argument& argument,
     Frame_Index frame,
     Context& context,
     const Match_Fail_Options& on_fail
 )
 {
-    COWEL_DEBUG_ASSERT(argument.is_value());
-
-    Result<Value, Processing_Status> val = evaluate_expression(argument, frame, context);
+    Result<Value, Processing_Status> val = argument.evaluate(frame, context);
     if (!val) {
         return status_max(val.error(), on_fail.status);
     }
-    if (!val->get_type().analytically_convertible_to(*m_expected_type)) {
+    if (!val->get_type().analytically_convertible_to(get_type())) {
         on_fail.emit(
-            argument.get_source_span(),
+            argument.get_value_location(),
             joined_char_sequence(
                 {
                     u8"Expected a value of type "sv,
-                    m_expected_type->get_display_name(),
+                    get_type().get_display_name(),
                     u8", but got "sv,
                     val->get_type().get_display_name(),
                     u8".",
@@ -67,38 +147,21 @@ Processing_Status Value_Of_Type_Matcher::match_value(
         );
         return on_fail.status;
     }
-    m_value = { std::move(val.value()), argument.get_source_span() };
+    m_value = { std::move(val.value()), argument.get_value_location() };
     return Processing_Status::ok;
 }
 
 Processing_Status Textual_Matcher::match_value(
-    const ast::Expression& argument,
+    const Argument& argument,
     Frame_Index frame,
     Context& context,
     const Match_Fail_Options& on_fail
 )
 {
     COWEL_DEBUG_ASSERT(status_is_error(on_fail.status));
-    COWEL_DEBUG_ASSERT(argument.is_value());
-
-    if (!argument.is_spliceable_value()) {
-        on_fail.emit(
-            argument.get_source_span(),
-            joined_char_sequence(
-                {
-                    u8"Expected a spliceable value, but got "sv,
-                    get_static_type(argument, context).get_display_name(),
-                    u8"."sv,
-                }
-            ),
-            context
-        );
-        return on_fail.status;
-    }
 
     std::pmr::vector<char8_t> buffer { context.get_transient_memory() };
-    const Processing_Status status
-        = splice_expression_to_plaintext(buffer, argument, frame, context);
+    const Processing_Status status = argument.splice_to_plaintext(buffer, frame, context);
     if (status != Processing_Status::ok) {
         return status;
     }
@@ -108,144 +171,118 @@ Processing_Status Textual_Matcher::match_value(
 }
 
 Processing_Status Spliceable_To_String_Matcher::match_value(
-    const ast::Expression& argument, //
+    const Argument& argument, //
     Frame_Index frame, //
     Context& context, //
     const Match_Fail_Options& on_fail
 )
 {
     COWEL_DEBUG_ASSERT(status_is_error(on_fail.status));
-    COWEL_DEBUG_ASSERT(argument.is_value());
-
-    if (!argument.is_spliceable_value()) {
-        on_fail.emit(
-            argument.get_source_span(),
-            joined_char_sequence(
-                {
-                    u8"Expected a spliceable value, but got "sv,
-                    get_static_type(argument, context).get_display_name(),
-                    u8"."sv,
-                }
-            ),
-            context
-        );
-        return on_fail.status;
-    }
 
     m_data.clear();
-    const Processing_Status status
-        = splice_expression_to_plaintext(m_data, argument, frame, context);
+    const Processing_Status status = argument.splice_to_plaintext(m_data, frame, context);
     if (status != Processing_Status::ok) {
         m_data.clear();
         return status;
     }
-    m_value = { as_u8string_view(m_data), argument.get_source_span() };
+    m_value = { as_u8string_view(m_data), argument.get_value_location() };
     return Processing_Status::ok;
 }
 
 Processing_Status String_Matcher::match_value(
-    const ast::Expression& argument, //
+    const Argument& argument, //
     Frame_Index frame, //
     Context& context, //
     const Match_Fail_Options& on_fail
 )
 {
     COWEL_DEBUG_ASSERT(status_is_error(on_fail.status));
-    COWEL_DEBUG_ASSERT(argument.is_spliceable_value());
 
-    const Result<Value, Processing_Status> val = evaluate_expression(argument, frame, context);
+    const Result<Value, Processing_Status> val = argument.evaluate(frame, context);
     if (!val) {
         return status_max(val.error(), on_fail.status);
     }
-    if (val->get_type() != Type::str) {
+    if (!val->is_str()) {
         // TODO: improve diagnostic
-        on_fail.emit(argument.get_source_span(), u8"Expected a string."sv, context);
+        on_fail.emit(argument.get_value_location(), u8"Expected a string."sv, context);
         return on_fail.status;
     }
     append(m_data, val->as_string());
 
-    m_value = { as_u8string_view(m_data), argument.get_source_span() };
+    m_value = { as_u8string_view(m_data), argument.get_value_location() };
     m_string_kind = val->get_string_kind();
     return Processing_Status::ok;
 }
 
 Processing_Status Boolean_Matcher::match_value(
-    const ast::Expression& argument,
+    const Argument& argument,
     Frame_Index frame,
     Context& context,
     const Match_Fail_Options& on_fail
 )
 {
-    COWEL_DEBUG_ASSERT(argument.is_spliceable_value());
-
-    const Result<Value, Processing_Status> val = evaluate_expression(argument, frame, context);
+    const Result<Value, Processing_Status> val = argument.evaluate(frame, context);
     if (!val) {
         return status_max(val.error(), on_fail.status);
     }
-    if (val->get_type() != Type::boolean) {
+    if (!val->is_bool()) {
         // TODO: improve diagnostic
         on_fail.emit(
-            argument.get_source_span(), u8"Expected a boolean (true or false)."sv, context
+            argument.get_value_location(), u8"Expected a boolean (true or false)."sv, context
         );
         return on_fail.status;
     }
-    m_value = { val.value().as_boolean(), argument.get_source_span() };
+    m_value = { val.value().as_boolean(), argument.get_value_location() };
     return Processing_Status::ok;
 }
 
 Processing_Status Integer_Matcher::match_value(
-    const ast::Expression& argument,
+    const Argument& argument,
     Frame_Index frame,
     Context& context,
     const Match_Fail_Options& on_fail
 )
 {
-    COWEL_DEBUG_ASSERT(argument.is_spliceable_value());
-
-    Result<Value, Processing_Status> val = evaluate_expression(argument, frame, context);
+    Result<Value, Processing_Status> val = argument.evaluate(frame, context);
     if (!val) {
         return status_max(val.error(), on_fail.status);
     }
-    if (val->get_type() != Type::integer) {
+    if (!val->is_int()) {
         // TODO: improve diagnostic
-        on_fail.emit(argument.get_source_span(), u8"Expected an integer."sv, context);
+        on_fail.emit(argument.get_value_location(), u8"Expected an integer."sv, context);
         return on_fail.status;
     }
-    m_value = { std::move(val.value().as_integer()), argument.get_source_span() };
+    m_value = { std::move(val.value().as_integer()), argument.get_value_location() };
     return Processing_Status::ok;
 }
 
 Processing_Status Float_Matcher::match_value(
-    const ast::Expression& argument,
+    const Argument& argument,
     Frame_Index frame,
     Context& context,
     const Match_Fail_Options& on_fail
 )
 {
-    COWEL_DEBUG_ASSERT(argument.is_spliceable_value());
-
-    const Result<Value, Processing_Status> val = evaluate_expression(argument, frame, context);
+    const Result<Value, Processing_Status> val = argument.evaluate(frame, context);
     if (!val) {
         return status_max(val.error(), on_fail.status);
     }
-    if (val->get_type() != Type::floating) {
+    if (!val->is_float()) {
         // TODO: improve diagnostic
-        on_fail.emit(argument.get_source_span(), u8"Expected a float."sv, context);
+        on_fail.emit(argument.get_value_location(), u8"Expected a float."sv, context);
         return on_fail.status;
     }
-    m_value = { val.value().as_float(), argument.get_source_span() };
+    m_value = { val.value().as_float(), argument.get_value_location() };
     return Processing_Status::ok;
 }
 
 bool Sorted_Options_Matcher::match_string(
-    const ast::Expression& argument,
+    const Argument& argument,
     std::u8string_view str,
     Context& context,
     Fail_Callback on_fail
 )
 {
-    COWEL_DEBUG_ASSERT(argument.is_spliceable_value());
-
     const auto it = std::ranges::lower_bound(m_options, str);
 
     if (it == m_options.end() || *it != str) {
@@ -265,90 +302,59 @@ bool Sorted_Options_Matcher::match_string(
             error += u8'"';
         }
         error += u8").";
-        on_fail(argument.get_source_span(), std::u8string_view(error), context);
+        on_fail(argument.get_value_location(), std::u8string_view(error), context);
         return false;
     }
 
     m_value = Value_And_Location<std::size_t> {
         .value = std::size_t(it - m_options.begin()),
-        .location = argument.get_source_span(),
+        .location = argument.get_value_location(),
     };
     return true;
 }
 
-Processing_Status Pack_Usual_Matcher::match_pack(
-    std::span<const ast::Group_Member> members,
+Processing_Status Block_Matcher::match_value(
+    const Argument& argument,
     Frame_Index frame,
     Context& context,
     const Match_Fail_Options& on_fail
 )
 {
-    COWEL_DEBUG_ASSERT(status_is_error(on_fail.status));
-
-    std::pmr::vector<int> indices(m_member_matchers.size(), -1, context.get_transient_memory());
-    return do_match(members, frame, context, on_fail, indices, 0);
-}
-
-Processing_Status Empty_Pack_Matcher::match_pack(
-    std::span<const ast::Group_Member> members,
-    Frame_Index frame,
-    Context& context,
-    const Match_Fail_Options& on_fail
-)
-{
-    COWEL_DEBUG_ASSERT(status_is_error(on_fail.status));
-
-    Processing_Status result_status = Processing_Status::ok;
-    for (const ast::Group_Member& arg : members) {
-        if (arg.get_kind() == ast::Member_Kind::ellipsis) {
-            const Stack_Frame& ellipsis_frame = context.get_call_stack()[frame];
-            const auto recursive_status = match_pack(
-                ellipsis_frame.invocation.get_arguments_span(),
-                ellipsis_frame.invocation.content_frame, context, on_fail
-            );
-            if (recursive_status != Processing_Status::ok) {
-                return recursive_status;
-            }
-        }
-        else {
-            on_fail.emit(
-                arg.get_source_span(),
-                u8"This argument does not match any parameter (no parameters are accepted)."sv,
-                context
-            );
-            if (on_fail.status == Processing_Status::fatal) {
-                return on_fail.status;
-            }
-            result_status = on_fail.status;
-        }
+    const Result<Value, Processing_Status> val = argument.evaluate(frame, context);
+    if (!val) {
+        return status_max(val.error(), on_fail.status);
     }
-    return result_status;
-}
-
-Processing_Status Group_Matcher::match_value(
-    const ast::Expression& argument,
-    Frame_Index frame,
-    Context& context,
-    const Match_Fail_Options& on_fail
-)
-{
-    COWEL_DEBUG_ASSERT(status_is_error(on_fail.status));
-
-    if (argument.is_directive()) {
-        on_fail.emit(
-            argument.get_source_span(), u8"Expected a group, but got directive."sv, context
-        );
+    if (!val->is_block()) {
+        // TODO: improve diagnostic
+        on_fail.emit(argument.get_value_location(), u8"Expected a block."sv, context);
         return on_fail.status;
     }
-    COWEL_ASSERT(argument.is_primary());
-    const auto& primary = argument.as_primary();
-    if (primary.get_kind() != ast::Primary_Kind::group) {
+    m_value = { val.value(), argument.get_value_location() };
+    return Processing_Status::ok;
+}
+
+Processing_Status Pack_Of_Type_Matcher::match_value(
+    const Argument& argument,
+    Frame_Index frame,
+    Context& context,
+    const Match_Fail_Options& on_fail
+)
+{
+    Result<Value, Processing_Status> val = argument.evaluate(frame, context);
+    if (!val) {
+        return status_max(val.error(), on_fail.status);
+    }
+    COWEL_DEBUG_ASSERT(get_type().is_pack());
+    const Type& element_type = get_type().get_members().front();
+    if (!val->get_type().analytically_convertible_to(element_type)) {
         on_fail.emit(
-            argument.get_source_span(),
+            argument.get_value_location(),
             joined_char_sequence(
                 {
-                    u8"Expected a group, but got "sv,
-                    ast::primary_kind_display_name(primary.get_kind()),
+                    u8"Expected an element of type "sv,
+                    element_type.get_display_name(),
+                    u8", but got "sv,
+                    val->get_type().get_display_name(),
                     u8"."sv,
                 }
             ),
@@ -356,57 +362,247 @@ Processing_Status Group_Matcher::match_value(
         );
         return on_fail.status;
     }
-    return match_group(&primary, frame, context, on_fail);
+    m_values.push_back({ .value = std::move(*val), .location = argument.get_value_location() });
+    return Processing_Status::ok;
 }
 
-Processing_Status Pack_Usual_Matcher::do_match(
-    std::span<const ast::Group_Member> members,
+Processing_Status Pack_Named_Of_Type_Matcher::match_value(
+    const Argument& argument,
     Frame_Index frame,
     Context& context,
-    const Match_Fail_Options& on_fail,
-    std::span<int> argument_indices_by_parameter,
-    std::size_t cumulative_arg_index
+    const Match_Fail_Options& on_fail
 )
 {
-    COWEL_DEBUG_ASSERT(status_is_error(on_fail.status));
+    COWEL_DEBUG_ASSERT(get_type().is_pack());
 
-    bool encountered_named = false;
+    if (!argument.is_named()) {
+        on_fail.emit(
+            argument.get_location(), //
+            u8"Expected a named argument, but got a positional one."sv, //
+            context
+        );
+        return on_fail.status;
+    }
 
-    for (std::size_t arg_index = 0; arg_index < members.size(); ++arg_index) {
-        const ast::Group_Member& member = members[arg_index];
+    Result<Value, Processing_Status> val = argument.evaluate(frame, context);
+    if (!val) {
+        return status_max(val.error(), on_fail.status);
+    }
+
+    if (!val->get_type().analytically_convertible_to(m_element_type)) {
+        on_fail.emit(
+            argument.get_value_location(),
+            joined_char_sequence(
+                {
+                    u8"Expected a named argument of type "sv,
+                    m_element_type.get_display_name(),
+                    u8", but got "sv,
+                    val->get_type().get_display_name(),
+                    u8"."sv,
+                }
+            ),
+            context
+        );
+        return on_fail.status;
+    }
+    m_values.push_back(
+        {
+            .name = argument.get_name(),
+            .value = std::move(*val),
+        }
+    );
+    m_locations.push_back(argument.get_location());
+    return Processing_Status::ok;
+}
+
+Processing_Status Group_Pack_Named_Str_Matcher::match_value(
+    const Argument& argument,
+    Frame_Index frame,
+    Context& context,
+    const Match_Fail_Options& on_fail
+)
+{
+    Result<Value, Processing_Status> val = argument.evaluate(frame, context);
+    if (!val) {
+        return status_max(val.error(), on_fail.status);
+    }
+    if (!val->is_group()) {
+        on_fail.emit(
+            argument.get_value_location(),
+            joined_char_sequence(
+                {
+                    u8"Expected a group, but got "sv,
+                    val->get_type().get_display_name(),
+                    u8"."sv,
+                }
+            ),
+            context
+        );
+        return on_fail.status;
+    }
+
+    for (const auto& [name, value] : val->get_group_members()) {
+        if (!name.is_str()) {
+            COWEL_ASSERT(name.is_null());
+            on_fail.emit(
+                argument.get_value_location(),
+                u8"Expected a named member, but got a positional one."sv, context
+            );
+            return on_fail.status;
+        }
+        if (!value.is_str()) {
+            on_fail.emit(
+                argument.get_value_location(),
+                joined_char_sequence(
+                    {
+                        u8"Group members must be of type "sv,
+                        Type::str.get_display_name(),
+                        u8", but got "sv,
+                        value.get_type().get_display_name(),
+                        u8"."sv,
+                    }
+                ),
+                context
+            );
+            return on_fail.status;
+        }
+    }
+
+    m_value = { std::move(*val), argument.get_value_location() };
+    return Processing_Status::ok;
+}
+
+namespace {
+
+enum struct Argument_Mode : Default_Underlying {
+    /// @brief Initial mode.
+    normal,
+    /// @brief Named-only mode.
+    /// After the first named argument, only more named arguments are accepted.
+    named_only,
+    /// @brief Variadic mode.
+    /// After matching an argument to a pack parameter,
+    /// all subsequent arguments are treated as part of that pack.
+    /// Named arguments are accepted and terminate the pack.
+    pack_positional,
+    /// @brief Variadic mode.
+    /// Pack of named arguments.
+    pack_named,
+};
+
+struct Match_Call {
+    const std::span<Parameter* const> parameters;
+    Context& context;
+    const Fail_Callback on_fail;
+    const Processing_Status on_fail_status;
+    const std::span<int> argument_indices_by_parameter;
+    Argument_Mode mode;
+    std::size_t current_pack_param_index;
+    Value_Matcher* current_pack_value_matcher;
+
+    [[nodiscard]]
+    Processing_Status operator()(
+        std::span<const ast::Group_Member> args,
+        Frame_Index frame,
+        std::size_t cumulative_arg_index
+    );
+};
+
+Processing_Status Match_Call::operator()(
+    const std::span<const ast::Group_Member> args,
+    const Frame_Index frame,
+    const std::size_t cumulative_arg_index
+)
+{
+    for (std::size_t arg_index = 0; arg_index < args.size(); ++arg_index) {
+        const ast::Group_Member& member = args[arg_index];
+        const Match_Fail_Options on_member_fail {
+            .emit = on_fail,
+            .status = on_fail_status,
+            .location = member.get_source_span(),
+        };
+
         switch (member.get_kind()) {
-
         case ast::Member_Kind::positional: {
-            if (encountered_named) {
+            const auto arg = Argument::positional(member);
+
+            switch (mode) {
+            case Argument_Mode::named_only:
+            case Argument_Mode::pack_named: {
                 // TODO: more detailed feedback
-                on_fail.emit(
+                on_fail(
                     member.get_source_span(),
                     u8"Providing a positional argument after a named argument is not valid."sv,
                     context
                 );
-                return on_fail.status;
+                return on_fail_status;
             }
-            if (arg_index + cumulative_arg_index >= argument_indices_by_parameter.size()) {
-                on_fail.emit(member.get_source_span(), u8"Too many arguments."sv, context);
-                return on_fail.status;
+
+            case Argument_Mode::pack_positional: {
+                // We shouldn't be in pack mode
+                // unless we have matched a pack parameter once in normal mode.
+                COWEL_ASSERT(current_pack_value_matcher);
+                COWEL_ASSERT(current_pack_param_index <= argument_indices_by_parameter.size());
+                COWEL_ASSERT(argument_indices_by_parameter[current_pack_param_index] != -1);
+
+                const auto arg_status
+                    = current_pack_value_matcher->match_value(arg, frame, context, on_member_fail);
+                if (arg_status != Processing_Status::ok) {
+                    return arg_status;
+                }
+                continue;
             }
-            argument_indices_by_parameter[arg_index + cumulative_arg_index] = int(arg_index);
-            const ast::Expression& value = member.get_value();
-            const auto member_status = m_member_matchers[arg_index + cumulative_arg_index]
-                                           ->get_value_matcher()
-                                           .match_value(value, frame, context, on_fail);
-            if (member_status != Processing_Status::ok) {
-                return member_status;
+
+            case Argument_Mode::normal: {
+                const std::size_t parameter_index = arg_index + cumulative_arg_index;
+                if (parameter_index >= argument_indices_by_parameter.size()) {
+                    on_fail(member.get_source_span(), u8"Too many arguments."sv, context);
+                    return on_fail_status;
+                }
+                if (argument_indices_by_parameter[parameter_index]
+                    == std::numeric_limits<int>::max()) {
+                    on_fail(
+                        member.get_source_span(),
+                        joined_char_sequence(
+                            {
+                                u8"This argument is invalid because the parameter \""sv,
+                                parameters[parameter_index]->get_name(),
+                                u8"\" has already been provided as a block argument.",
+                            }
+                        ),
+                        context
+                    );
+                    return on_fail_status;
+                }
+                // No other failure is possible:
+                // named arguments can only be provided after positional arguments,
+                // and positional arguments wouldn't match a parameter more than once.
+                COWEL_ASSERT(argument_indices_by_parameter[parameter_index] == -1);
+
+                // FIXME: pretty sure this should be = parameter_index
+                argument_indices_by_parameter[parameter_index] = int(arg_index);
+                Value_Matcher& value_matcher = parameters[parameter_index]->get_value_matcher();
+                const auto arg_status
+                    = value_matcher.match_value(arg, frame, context, on_member_fail);
+                if (arg_status != Processing_Status::ok) {
+                    return arg_status;
+                }
+                if (value_matcher.get_type().is_pack()) {
+                    mode = Argument_Mode::pack_positional;
+                    current_pack_param_index = parameter_index;
+                    current_pack_value_matcher = &value_matcher;
+                }
+                continue;
             }
-            continue;
+            }
+            COWEL_ASSERT_UNREACHABLE(u8"Invalid mode.");
         }
 
         case ast::Member_Kind::ellipsis: {
             const Stack_Frame& ellipsis_frame = context.get_call_stack()[frame];
-            const auto recursive_status = do_match(
+            const auto recursive_status = (*this)(
                 ellipsis_frame.invocation.get_arguments_span(),
-                ellipsis_frame.invocation.content_frame, context, on_fail,
-                argument_indices_by_parameter, cumulative_arg_index + arg_index
+                ellipsis_frame.invocation.content_frame, cumulative_arg_index + arg_index
             );
             if (recursive_status != Processing_Status::ok) {
                 return recursive_status;
@@ -415,20 +611,69 @@ Processing_Status Pack_Usual_Matcher::do_match(
         }
 
         case ast::Member_Kind::named: {
-            encountered_named = true;
-            Result<Value, Processing_Status> arg_name_value
+            Result<Value, Processing_Status> name_result
                 = evaluate(member.get_name(), frame, context);
-            if (!arg_name_value) {
-                return arg_name_value.error();
+            if (!name_result) {
+                return status_max(on_fail_status, name_result.error());
             }
-            const std::u8string_view arg_name = arg_name_value->as_string();
-            for (std::size_t i = 0; i < m_member_matchers.size(); ++i) {
-                auto* const member_matcher = m_member_matchers[i];
+            COWEL_ASSERT(name_result->is_str());
+
+            const auto arg = Argument::named(std::move(*name_result), member);
+            const std::u8string_view arg_name = arg.get_name().as_string();
+
+            // Handle pack of named arguments, i.e. parameters of type "pack named any".
+            // This should only be possible in normal mode because otherwise,
+            // there is an ambiguity between providing a named argument that goes into the pack
+            // and one that applies to a prior positional parameter.
+            if (mode == Argument_Mode::normal) {
+                const std::size_t parameter_index = arg_index + cumulative_arg_index;
+                if (parameter_index < argument_indices_by_parameter.size()) {
+                    auto* const parameter = parameters[parameter_index];
+                    const bool is_pack_named = parameter->get_type().is_pack()
+                        && parameter->get_type().get_members().front().is_named();
+                    if (is_pack_named) {
+                        argument_indices_by_parameter[parameter_index] = int(parameter_index);
+                        current_pack_value_matcher = &parameter->get_value_matcher();
+                        current_pack_param_index = parameter_index;
+                        mode = Argument_Mode::pack_named;
+                        const auto arg_status = parameter->get_value_matcher().match_value(
+                            arg, frame, context, on_member_fail
+                        );
+                        if (arg_status != Processing_Status::ok) {
+                            return arg_status;
+                        }
+                        goto named_parameter_matched;
+                    }
+                }
+            }
+            // If we are already in a pack of named arguments and provide another named argument,
+            // we simply append it to the pack.
+            else if (mode == Argument_Mode::pack_named) {
+                COWEL_ASSERT(current_pack_value_matcher);
+                COWEL_ASSERT(current_pack_param_index <= argument_indices_by_parameter.size());
+                COWEL_ASSERT(argument_indices_by_parameter[current_pack_param_index] != -1);
+
+                const auto arg_status
+                    = current_pack_value_matcher->match_value(arg, frame, context, on_member_fail);
+                if (arg_status != Processing_Status::ok) {
+                    return arg_status;
+                }
+                goto named_parameter_matched;
+            }
+
+            COWEL_DEBUG_ASSERT(mode != Argument_Mode::pack_named);
+            mode = Argument_Mode::named_only;
+            // Otherwise, in the normal case, for the named argument,
+            // we need to find a parameter with the same name.
+            // Providing the same named argument twice or providing a named argument
+            // without a corresponding parameter need to be diagnosed.
+            for (std::size_t i = 0; i < parameters.size(); ++i) {
+                auto* const member_matcher = parameters[i];
                 if (arg_name != member_matcher->get_name()) {
                     continue;
                 }
                 if (argument_indices_by_parameter[i] != -1) {
-                    on_fail.emit(
+                    on_fail(
                         member.get_name_span(),
                         joined_char_sequence(
                             {
@@ -439,18 +684,19 @@ Processing_Status Pack_Usual_Matcher::do_match(
                         ),
                         context
                     );
-                    return on_fail.status;
+                    return on_fail_status;
                 }
+                // FIXME: Pretty sure this should be = parameter_index
                 argument_indices_by_parameter[i] = int(arg_index);
-                const auto member_status = member_matcher->get_value_matcher().match_value(
-                    member.get_value(), frame, context, on_fail
+                const auto arg_status = member_matcher->get_value_matcher().match_value(
+                    arg, frame, context, on_member_fail
                 );
-                if (member_status != Processing_Status::ok) {
-                    return member_status;
+                if (arg_status != Processing_Status::ok) {
+                    return arg_status;
                 }
                 goto named_parameter_matched;
             }
-            on_fail.emit(
+            on_fail(
                 member.get_name_span(),
                 joined_char_sequence(
                     {
@@ -461,7 +707,8 @@ Processing_Status Pack_Usual_Matcher::do_match(
                 ),
                 context
             );
-            return on_fail.status;
+            return on_fail_status;
+
         named_parameter_matched:
             continue;
         }
@@ -469,114 +716,89 @@ Processing_Status Pack_Usual_Matcher::do_match(
         COWEL_ASSERT_UNREACHABLE(u8"Invalid member kind.");
     }
 
-    for (Group_Member_Matcher* const member_matcher : m_member_matchers) {
-        if (member_matcher->is_mandatory() && !member_matcher->get_value_matcher().was_matched()) {
-            on_fail.emit(
-                on_fail.location,
+    return Processing_Status::ok;
+}
+
+} // namespace
+
+Processing_Status match_call(
+    const std::span<Parameter* const> parameters,
+    const Invocation& call,
+    Context& context,
+    Fail_Callback on_fail,
+    Processing_Status on_fail_status
+)
+{
+    COWEL_ASSERT(on_fail);
+    COWEL_ASSERT(status_is_error(on_fail_status));
+    if constexpr (is_debug_build) {
+        for (const auto* const matcher : parameters) {
+            COWEL_ASSERT(matcher != nullptr);
+        }
+    }
+
+    Small_Vector<int, 32> argument_indices_by_parameter(parameters.size(), -1);
+
+    if (call.content) {
+        if (parameters.empty()) {
+            on_fail(
+                call.content->get_source_span(), //
+                u8"Block argument does not match any parameter."sv, //
+                context
+            );
+            return Processing_Status::error;
+        }
+        const auto arg = Argument::block(*call.content);
+        const Match_Fail_Options fail_options {
+            .emit = on_fail,
+            .status = on_fail_status,
+            .location = call.content->get_source_span(),
+        };
+        const Processing_Status block_status = parameters.back()->get_value_matcher().match_value(
+            arg, call.content_frame, context, fail_options
+        );
+        if (block_status != Processing_Status::ok) {
+            return block_status;
+        }
+        argument_indices_by_parameter.back() = std::numeric_limits<int>::max();
+    }
+
+    Match_Call match_call {
+        .parameters = parameters,
+        .context = context,
+        .on_fail = on_fail,
+        .on_fail_status = on_fail_status,
+        .argument_indices_by_parameter = argument_indices_by_parameter,
+        .mode = Argument_Mode::normal,
+        .current_pack_param_index = -1uz,
+        .current_pack_value_matcher = nullptr,
+    };
+    const Processing_Status status = match_call(
+        call.get_arguments_span(), //
+        call.content_frame, //
+        /* cumulative_arg_index= */ 0
+    );
+    if (status != Processing_Status::ok) {
+        return status;
+    }
+
+    for (Parameter* const p : parameters) {
+        if (p->is_mandatory() && !p->get_value_matcher().was_matched()) {
+            on_fail(
+                call.directive.get_name_span(),
                 joined_char_sequence(
                     {
                         u8"No argument for parameter \"",
-                        member_matcher->get_name(),
+                        p->get_name(),
                         u8"\" was provided.",
                     }
                 ),
                 context
             );
-            return on_fail.status;
+            return on_fail_status;
         }
     }
 
-    return Processing_Status::ok;
-}
-
-Processing_Status Group_Pack_Named_Lazy_Any_Matcher::match_pack(
-    std::span<const ast::Group_Member> members,
-    Frame_Index frame,
-    Context& context,
-    const Match_Fail_Options& on_fail
-)
-{
-    for (const ast::Group_Member& member : members) {
-        switch (member.get_kind()) {
-        case ast::Member_Kind::named: {
-            if (m_filter && !m_filter(member)) {
-                // TODO: add customizable warning within the filter
-                on_fail.emit(
-                    member.get_name_span(),
-                    u8"This member does not satisfy the type requirements."sv, context
-                );
-                return on_fail.status;
-            }
-            continue;
-        }
-        case ast::Member_Kind::ellipsis: {
-            const Stack_Frame& ellipsis_frame = context.get_call_stack()[frame];
-            const auto recursive_status = match_pack(
-                ellipsis_frame.invocation.get_arguments_span(),
-                ellipsis_frame.invocation.content_frame, context, on_fail
-            );
-            if (recursive_status != Processing_Status::ok) {
-                return recursive_status;
-            }
-            continue;
-        }
-        case ast::Member_Kind::positional: {
-            on_fail.emit(
-                member.get_source_span(),
-                u8"Only named arguments can be provided here, not positional arguments."sv, context
-            );
-            return on_fail.status;
-        }
-        }
-    }
-    return Processing_Status::ok;
-}
-
-[[nodiscard]]
-Processing_Status Group_Pack_Value_Matcher::match_pack(
-    std::span<const ast::Group_Member> members,
-    Frame_Index frame,
-    Context& context,
-    const Match_Fail_Options& on_fail
-)
-{
-    COWEL_DEBUG_ASSERT(status_is_error(on_fail.status));
-
-    for (const ast::Group_Member& member : members) {
-        switch (member.get_kind()) {
-
-        case ast::Member_Kind::positional: {
-            Result<Value, Processing_Status> member_result
-                = evaluate_expression(member.get_value(), frame, context);
-            if (!member_result) {
-                return status_max(member_result.error(), on_fail.status);
-            }
-            m_values.push_back({ std::move(*member_result), member.get_source_span() });
-            continue;
-        }
-
-        case ast::Member_Kind::named: {
-            on_fail.emit(
-                member.get_name_span(),
-                u8"A pack of values was expected here. Named arguments cannot be provided."sv,
-                context
-            );
-            return on_fail.status;
-        }
-
-        case ast::Member_Kind::ellipsis: {
-            const Stack_Frame& ellipsis_frame = context.get_call_stack()[frame];
-            const auto recursive_status = match_pack(
-                ellipsis_frame.invocation.get_arguments_span(),
-                ellipsis_frame.invocation.content_frame, context, on_fail
-            );
-            if (recursive_status != Processing_Status::ok) {
-                return recursive_status;
-            }
-            continue;
-        }
-        }
-    }
     return Processing_Status::ok;
 }
 

--- a/src/main/cpp/semantics.cpp
+++ b/src/main/cpp/semantics.cpp
@@ -2,7 +2,6 @@
 #include <ranges>
 #include <span>
 #include <string>
-#include <vector>
 
 #include "cowel/expression_kind.hpp"
 #include "cowel/util/assert.hpp"
@@ -69,7 +68,6 @@ Value Value::block(const ast::Primary& block, Frame_Index frame)
 
 Value Value::block(const ast::Directive& block, Frame_Index frame)
 {
-    // TODO: assertions
     return Value { Union { .directive = Directive_And_Frame { &block, frame } }, directive_index };
 }
 

--- a/src/test/cpp/test_small_vector.cpp
+++ b/src/test/cpp/test_small_vector.cpp
@@ -1023,6 +1023,165 @@ TEST(Small_Vector, grow_with_existing_allocation)
     EXPECT_EQ(object_count, 0);
 }
 
+TEST(Small_Vector, resize_to_zero)
+{
+    object_count = 0;
+    {
+        Small_Vector<Counted, 4> vec;
+        vec.push_back(Counted { 1 });
+        vec.push_back(Counted { 2 });
+        vec.push_back(Counted { 3 });
+        EXPECT_EQ(vec.size(), 3);
+        EXPECT_TRUE(vec.small());
+        EXPECT_EQ(object_count, 4);
+
+        vec.resize(0);
+        EXPECT_EQ(vec.size(), 0);
+        EXPECT_TRUE(vec.empty());
+        EXPECT_TRUE(vec.small());
+        EXPECT_EQ(object_count, 4);
+    }
+    EXPECT_EQ(object_count, 0);
+}
+
+TEST(Small_Vector, resize_shrink_small)
+{
+    object_count = 0;
+    {
+        Small_Vector<Counted, 4> vec;
+        vec.push_back(Counted { 1 });
+        vec.push_back(Counted { 2 });
+        vec.push_back(Counted { 3 });
+        EXPECT_EQ(vec.size(), 3);
+        EXPECT_TRUE(vec.small());
+        EXPECT_EQ(object_count, 4);
+
+        vec.resize(1);
+        EXPECT_EQ(vec.size(), 1);
+        EXPECT_TRUE(vec.small());
+        EXPECT_EQ(object_count, 4);
+        EXPECT_EQ(vec[0].value, 1);
+    }
+    EXPECT_EQ(object_count, 0);
+}
+
+TEST(Small_Vector, resize_shrink_dynamic)
+{
+    object_count = 0;
+    {
+        Small_Vector<Counted, 2> vec;
+        vec.push_back(Counted { 1 });
+        vec.push_back(Counted { 2 });
+        vec.push_back(Counted { 3 });
+        vec.push_back(Counted { 4 });
+        vec.push_back(Counted { 5 });
+        EXPECT_EQ(vec.size(), 5);
+        EXPECT_FALSE(vec.small());
+        EXPECT_EQ(object_count, 7);
+
+        vec.resize(2);
+        EXPECT_EQ(vec.size(), 2);
+        EXPECT_FALSE(vec.small());
+        EXPECT_EQ(object_count, 4);
+        EXPECT_EQ(vec[0].value, 1);
+        EXPECT_EQ(vec[1].value, 2);
+    }
+    EXPECT_EQ(object_count, 0);
+}
+
+TEST(Small_Vector, resize_grow_within_small)
+{
+    object_count = 0;
+    {
+        Small_Vector<Counted, 4> vec;
+        vec.push_back(Counted { 1 });
+        EXPECT_EQ(vec.size(), 1);
+        EXPECT_TRUE(vec.small());
+        EXPECT_EQ(object_count, 4);
+
+        vec.resize(3);
+        EXPECT_EQ(vec.size(), 3);
+        EXPECT_TRUE(vec.small());
+        EXPECT_EQ(object_count, 4);
+        EXPECT_EQ(vec[0].value, 1);
+        EXPECT_EQ(vec[1].value, 0);
+        EXPECT_EQ(vec[2].value, 0);
+    }
+    EXPECT_EQ(object_count, 0);
+}
+
+TEST(Small_Vector, resize_grow_to_dynamic)
+{
+    object_count = 0;
+    {
+        Small_Vector<Counted, 2> vec;
+        vec.push_back(Counted { 1 });
+        EXPECT_EQ(vec.size(), 1);
+        EXPECT_TRUE(vec.small());
+        EXPECT_EQ(object_count, 2);
+
+        vec.resize(5);
+        EXPECT_EQ(vec.size(), 5);
+        EXPECT_FALSE(vec.small());
+        EXPECT_GE(vec.capacity(), 5);
+        EXPECT_EQ(object_count, 7);
+        EXPECT_EQ(vec[0].value, 1);
+        EXPECT_EQ(vec[1].value, 0);
+        EXPECT_EQ(vec[2].value, 0);
+        EXPECT_EQ(vec[3].value, 0);
+        EXPECT_EQ(vec[4].value, 0);
+    }
+    EXPECT_EQ(object_count, 0);
+}
+
+TEST(Small_Vector, resize_grow_dynamic)
+{
+    object_count = 0;
+    {
+        Small_Vector<Counted, 2> vec;
+        vec.push_back(Counted { 1 });
+        vec.push_back(Counted { 2 });
+        vec.push_back(Counted { 3 });
+        EXPECT_EQ(vec.size(), 3);
+        EXPECT_FALSE(vec.small());
+        EXPECT_EQ(object_count, 5);
+
+        vec.resize(6);
+        EXPECT_EQ(vec.size(), 6);
+        EXPECT_FALSE(vec.small());
+        EXPECT_GE(vec.capacity(), 6);
+        EXPECT_EQ(object_count, 8);
+        EXPECT_EQ(vec[0].value, 1);
+        EXPECT_EQ(vec[1].value, 2);
+        EXPECT_EQ(vec[2].value, 3);
+        EXPECT_EQ(vec[3].value, 0);
+        EXPECT_EQ(vec[4].value, 0);
+        EXPECT_EQ(vec[5].value, 0);
+    }
+    EXPECT_EQ(object_count, 0);
+}
+
+TEST(Small_Vector, resize_same_size)
+{
+    object_count = 0;
+    {
+        Small_Vector<Counted, 4> vec;
+        vec.push_back(Counted { 1 });
+        vec.push_back(Counted { 2 });
+        EXPECT_EQ(vec.size(), 2);
+        EXPECT_TRUE(vec.small());
+        EXPECT_EQ(object_count, 4);
+
+        vec.resize(2);
+        EXPECT_EQ(vec.size(), 2);
+        EXPECT_TRUE(vec.small());
+        EXPECT_EQ(object_count, 4);
+        EXPECT_EQ(vec[0].value, 1);
+        EXPECT_EQ(vec[1].value, 2);
+    }
+    EXPECT_EQ(object_count, 0);
+}
+
 consteval int f()
 {
     Small_Vector<int, 16> v;

--- a/test/semantics/paragraphs/paragraph_control.cow
+++ b/test/semantics/paragraphs/paragraph_control.cow
@@ -9,9 +9,9 @@ Second paragraph.
 
 Fifth \cowel_paragraph_leave paragraph.
 
-\cowel_paragraph_enter\cowel_paragraph_enter\cowel_paragraph_enter{}Sixth paragraph.
+\cowel_paragraph_enter\cowel_paragraph_enter\cowel_paragraph_enter()Sixth paragraph.
 
-\cowel_paragraph_leave\cowel_paragraph_leave\cowel_paragraph_leave{}Seventh paragraph.
+\cowel_paragraph_leave\cowel_paragraph_leave\cowel_paragraph_leave()Seventh paragraph.
 
 Eight paragraph.\cowel_paragraph_leave\cowel_paragraph_leave\cowel_paragraph_leave
 }}

--- a/test/semantics/paragraphs/paragraphs_deep.cow
+++ b/test/semantics/paragraphs/paragraphs_deep.cow
@@ -1,6 +1,6 @@
 \test_input{\cowel_paragraphs{
-\i{\cowel_paragraph_leave{}awoo}
-\cowel_paragraph_leave{}\cowel_text_as_html{End.}
+\i{\cowel_paragraph_leave()awoo}
+\cowel_paragraph_leave()\cowel_text_as_html{End.}
 }}
 
 \test_output{


### PR DESCRIPTION
First and foremost, this change is a major refactor of processing of builtin directives. These now all use unified semantics, and are implemented using a list of Parameter objects.

Secondly, block arguments are no longer treated specially, but behave as if the block was provided as an argument for the last parameter of the directive. This is very similar to how Kotlin lambdas can be provided outside the parameter list.

Various latent bugs in directives are also fixed as a result. The `trim` directive is being removed because its semantics don't fit into a processing model where blocks are not subject to AST manipulation.