### PR TITLE
Fix highlighting splice in string

### DIFF
--- a/editor/vscode/package.json
+++ b/editor/vscode/package.json
@@ -59,6 +59,13 @@
         "language": "cowel",
         "scopeName": "source.cowel",
         "path": "./syntaxes/cowel.tmLanguage.json",
+        "tokenTypes": {
+          "punctuation.section.arguments.begin.cowel": "other",
+          "punctuation.section.arguments.end.cowel": "other",
+          "punctuation.section.content.begin.cowel": "other",
+          "punctuation.section.content.end.cowel": "other",
+          "support.function.directive.cowel": "other"
+        },
         "balancedBracketScopes": [
           "*"
         ],

--- a/editor/vscode/syntaxes/cowel.tmLanguage.json
+++ b/editor/vscode/syntaxes/cowel.tmLanguage.json
@@ -56,7 +56,7 @@
       "patterns": [
         {
           "name": "meta.arguments.cowel",
-          "begin": "(?<!\\))\\(",
+          "begin": "\\G\\(",
           "beginCaptures": {
             "0": { "name": "punctuation.section.arguments.begin.cowel" }
           },
@@ -75,7 +75,7 @@
       "patterns": [
         {
           "name": "meta.content.cowel",
-          "begin": "(?<![\\)\\}])\\{",
+          "begin": "\\G\\{",
           "beginCaptures": {
             "0": { "name": "punctuation.section.content.begin.cowel" }
           },

--- a/editor/vscode/syntaxes/cowel.tmLanguage.json
+++ b/editor/vscode/syntaxes/cowel.tmLanguage.json
@@ -56,7 +56,7 @@
       "patterns": [
         {
           "name": "meta.arguments.cowel",
-          "begin": "\\G\\(",
+          "begin": "(?<!\\))\\(",
           "beginCaptures": {
             "0": { "name": "punctuation.section.arguments.begin.cowel" }
           },
@@ -75,7 +75,7 @@
       "patterns": [
         {
           "name": "meta.content.cowel",
-          "begin": "\\G\\{",
+          "begin": "(?<![\\)\\}])\\{",
           "beginCaptures": {
             "0": { "name": "punctuation.section.content.begin.cowel" }
           },

--- a/editor/vscode/tests/fixtures/dir-splice-in-str.cowel
+++ b/editor/vscode/tests/fixtures/dir-splice-in-str.cowel
@@ -1,2 +1,2 @@
-\dir("\splice")\
-\dir("\splice e")\
+\d("\x{abc}")
+\d("\x(100)")

--- a/editor/vscode/tests/fixtures/dir-splice-in-str.cowel
+++ b/editor/vscode/tests/fixtures/dir-splice-in-str.cowel
@@ -1,2 +1,4 @@
+\dir("\splice")\
+\dir("\splice e")\
 \d("\x{abc}")
 \d("\x(100)")

--- a/editor/vscode/tests/fixtures/dir-splice-in-str.cowel.json
+++ b/editor/vscode/tests/fixtures/dir-splice-in-str.cowel.json
@@ -1,5 +1,5 @@
 {
-  "description": "Test directive splices inside quoted strings",
+  "description": "Test directive splices with groups and blocks inside quoted strings",
   "assertions": [
     {
       "type": "top-scope",
@@ -11,16 +11,30 @@
     {
       "type": "top-scope",
       "line": 0,
-      "col": 7,
+      "col": 4,
       "expected": "support.function.directive.cowel",
       "description": "Directive splice inside string has correct scope"
     },
     {
       "type": "token-has-scope",
       "line": 0,
-      "col": 7,
+      "col": 4,
       "scope": "string.quoted.double.cowel",
       "description": "Directive splice inside string still has string parent scope"
+    },
+    {
+      "type": "top-scope",
+      "line": 0,
+      "col": 6,
+      "expected": "punctuation.section.content.begin.cowel",
+      "description": "Opening brace after splice directive is highlighted"
+    },
+    {
+      "type": "top-scope",
+      "line": 0,
+      "col": 10,
+      "expected": "punctuation.section.content.end.cowel",
+      "description": "Closing brace after splice directive is highlighted"
     },
     {
       "type": "top-scope",
@@ -32,16 +46,37 @@
     {
       "type": "top-scope",
       "line": 1,
-      "col": 7,
+      "col": 4,
       "expected": "support.function.directive.cowel",
-      "description": "Directive splice inside string (with trailing text) has correct scope"
+      "description": "Splice directive with argument group has correct scope"
+    },
+    {
+      "type": "top-scope",
+      "line": 1,
+      "col": 6,
+      "expected": "punctuation.section.arguments.begin.cowel",
+      "description": "Opening parenthesis after splice directive is highlighted"
+    },
+    {
+      "type": "top-scope",
+      "line": 1,
+      "col": 7,
+      "expected": "constant.numeric.integer.decimal.cowel",
+      "description": "Numeric literal inside splice argument group is highlighted"
+    },
+    {
+      "type": "top-scope",
+      "line": 1,
+      "col": 10,
+      "expected": "punctuation.section.arguments.end.cowel",
+      "description": "Closing parenthesis after splice directive is highlighted"
     },
     {
       "type": "token-has-scope",
       "line": 1,
-      "col": 14,
+      "col": 4,
       "scope": "string.quoted.double.cowel",
-      "description": "Text after directive splice still has string scope"
+      "description": "Splice directive in second line still has string parent scope"
     }
   ]
 }

--- a/editor/vscode/tests/fixtures/dir-splice-in-str.cowel.json
+++ b/editor/vscode/tests/fixtures/dir-splice-in-str.cowel.json
@@ -1,5 +1,5 @@
 {
-  "description": "Test directive splices inside quoted strings (original cases + new splice cases)",
+  "description": "Test directive splices inside quoted strings",
   "assertions": [
     {
       "type": "top-scope",

--- a/editor/vscode/tests/fixtures/dir-splice-in-str.cowel.json
+++ b/editor/vscode/tests/fixtures/dir-splice-in-str.cowel.json
@@ -6,42 +6,42 @@
       "line": 0,
       "col": 1,
       "expected": "support.function.directive.cowel",
-      "description": "Original: outer directive has correct scope"
+      "description": "Outer directive has correct scope"
     },
     {
       "type": "top-scope",
       "line": 0,
       "col": 7,
       "expected": "support.function.directive.cowel",
-      "description": "Original: directive splice inside string has correct scope"
+      "description": "Directive splice inside string has correct scope"
     },
     {
       "type": "token-has-scope",
       "line": 0,
       "col": 7,
       "scope": "string.quoted.double.cowel",
-      "description": "Original: directive splice inside string still has string parent scope"
+      "description": "Directive splice inside string still has string parent scope"
     },
     {
       "type": "top-scope",
       "line": 1,
       "col": 1,
       "expected": "support.function.directive.cowel",
-      "description": "Original: second outer directive has correct scope"
+      "description": "Second outer directive has correct scope"
     },
     {
       "type": "top-scope",
       "line": 1,
       "col": 7,
       "expected": "support.function.directive.cowel",
-      "description": "Original: directive splice inside string (with trailing text) has correct scope"
+      "description": "Directive splice inside string (with trailing text) has correct scope"
     },
     {
       "type": "token-has-scope",
       "line": 1,
       "col": 14,
       "scope": "string.quoted.double.cowel",
-      "description": "Original: text after directive splice still has string scope"
+      "description": "Text after directive splice still has string scope"
     },
     {
       "type": "top-scope",
@@ -55,70 +55,70 @@
       "line": 2,
       "col": 4,
       "expected": "support.function.directive.cowel",
-      "description": "New splice (braces): directive splice inside string has correct scope"
+      "description": "Splice (braces): directive splice inside string has correct scope"
     },
     {
       "type": "token-has-scope",
       "line": 2,
       "col": 4,
       "scope": "string.quoted.double.cowel",
-      "description": "New splice (braces): directive splice inside string still has string parent scope"
+      "description": "Splice (braces): directive splice inside string still has string parent scope"
     },
     {
       "type": "top-scope",
       "line": 2,
       "col": 6,
       "expected": "punctuation.section.content.begin.cowel",
-      "description": "New splice (braces): opening brace after splice directive is highlighted"
+      "description": "Splice (braces): opening brace after splice directive is highlighted"
     },
     {
       "type": "top-scope",
       "line": 2,
       "col": 10,
       "expected": "punctuation.section.content.end.cowel",
-      "description": "New splice (braces): closing brace after splice directive is highlighted"
+      "description": "Splice (braces): closing brace after splice directive is highlighted"
     },
     {
       "type": "top-scope",
       "line": 3,
       "col": 1,
       "expected": "support.function.directive.cowel",
-      "description": "New splice (parens): outer directive has correct scope"
+      "description": "Splice (parens): outer directive has correct scope"
     },
     {
       "type": "top-scope",
       "line": 3,
       "col": 4,
       "expected": "support.function.directive.cowel",
-      "description": "New splice (parens): splice directive with argument group has correct scope"
+      "description": "Splice (parens): splice directive with argument group has correct scope"
     },
     {
       "type": "top-scope",
       "line": 3,
       "col": 6,
       "expected": "punctuation.section.arguments.begin.cowel",
-      "description": "New splice (parens): opening parenthesis after splice directive is highlighted"
+      "description": "Splice (parens): opening parenthesis after splice directive is highlighted"
     },
     {
       "type": "top-scope",
       "line": 3,
       "col": 7,
       "expected": "constant.numeric.integer.decimal.cowel",
-      "description": "New splice (parens): numeric literal inside splice argument group is highlighted"
+      "description": "Splice (parens): numeric literal inside splice argument group is highlighted"
     },
     {
       "type": "top-scope",
       "line": 3,
       "col": 10,
       "expected": "punctuation.section.arguments.end.cowel",
-      "description": "New splice (parens): closing parenthesis after splice directive is highlighted"
+      "description": "Splice (parens): closing parenthesis after splice directive is highlighted"
     },
     {
       "type": "token-has-scope",
       "line": 3,
       "col": 4,
       "scope": "string.quoted.double.cowel",
-      "description": "New splice (parens): splice directive in line still has string parent scope"
+      "description": "Splice (parens): splice directive in line still has string parent scope"
     }
   ]
 }

--- a/editor/vscode/tests/fixtures/dir-splice-in-str.cowel.json
+++ b/editor/vscode/tests/fixtures/dir-splice-in-str.cowel.json
@@ -1,82 +1,124 @@
 {
-  "description": "Test directive splices with groups and blocks inside quoted strings",
+  "description": "Test directive splices inside quoted strings (original cases + new splice cases)",
   "assertions": [
     {
       "type": "top-scope",
       "line": 0,
       "col": 1,
       "expected": "support.function.directive.cowel",
-      "description": "Outer directive has correct scope"
+      "description": "Original: outer directive has correct scope"
     },
     {
       "type": "top-scope",
       "line": 0,
-      "col": 4,
+      "col": 7,
       "expected": "support.function.directive.cowel",
-      "description": "Directive splice inside string has correct scope"
+      "description": "Original: directive splice inside string has correct scope"
     },
     {
       "type": "token-has-scope",
       "line": 0,
-      "col": 4,
+      "col": 7,
       "scope": "string.quoted.double.cowel",
-      "description": "Directive splice inside string still has string parent scope"
-    },
-    {
-      "type": "top-scope",
-      "line": 0,
-      "col": 6,
-      "expected": "punctuation.section.content.begin.cowel",
-      "description": "Opening brace after splice directive is highlighted"
-    },
-    {
-      "type": "top-scope",
-      "line": 0,
-      "col": 10,
-      "expected": "punctuation.section.content.end.cowel",
-      "description": "Closing brace after splice directive is highlighted"
+      "description": "Original: directive splice inside string still has string parent scope"
     },
     {
       "type": "top-scope",
       "line": 1,
       "col": 1,
       "expected": "support.function.directive.cowel",
-      "description": "Second outer directive has correct scope"
-    },
-    {
-      "type": "top-scope",
-      "line": 1,
-      "col": 4,
-      "expected": "support.function.directive.cowel",
-      "description": "Splice directive with argument group has correct scope"
-    },
-    {
-      "type": "top-scope",
-      "line": 1,
-      "col": 6,
-      "expected": "punctuation.section.arguments.begin.cowel",
-      "description": "Opening parenthesis after splice directive is highlighted"
+      "description": "Original: second outer directive has correct scope"
     },
     {
       "type": "top-scope",
       "line": 1,
       "col": 7,
-      "expected": "constant.numeric.integer.decimal.cowel",
-      "description": "Numeric literal inside splice argument group is highlighted"
-    },
-    {
-      "type": "top-scope",
-      "line": 1,
-      "col": 10,
-      "expected": "punctuation.section.arguments.end.cowel",
-      "description": "Closing parenthesis after splice directive is highlighted"
+      "expected": "support.function.directive.cowel",
+      "description": "Original: directive splice inside string (with trailing text) has correct scope"
     },
     {
       "type": "token-has-scope",
       "line": 1,
+      "col": 14,
+      "scope": "string.quoted.double.cowel",
+      "description": "Original: text after directive splice still has string scope"
+    },
+    {
+      "type": "top-scope",
+      "line": 2,
+      "col": 1,
+      "expected": "support.function.directive.cowel",
+      "description": "New splice (braces): outer directive has correct scope"
+    },
+    {
+      "type": "top-scope",
+      "line": 2,
+      "col": 4,
+      "expected": "support.function.directive.cowel",
+      "description": "New splice (braces): directive splice inside string has correct scope"
+    },
+    {
+      "type": "token-has-scope",
+      "line": 2,
       "col": 4,
       "scope": "string.quoted.double.cowel",
-      "description": "Splice directive in second line still has string parent scope"
+      "description": "New splice (braces): directive splice inside string still has string parent scope"
+    },
+    {
+      "type": "top-scope",
+      "line": 2,
+      "col": 6,
+      "expected": "punctuation.section.content.begin.cowel",
+      "description": "New splice (braces): opening brace after splice directive is highlighted"
+    },
+    {
+      "type": "top-scope",
+      "line": 2,
+      "col": 10,
+      "expected": "punctuation.section.content.end.cowel",
+      "description": "New splice (braces): closing brace after splice directive is highlighted"
+    },
+    {
+      "type": "top-scope",
+      "line": 3,
+      "col": 1,
+      "expected": "support.function.directive.cowel",
+      "description": "New splice (parens): outer directive has correct scope"
+    },
+    {
+      "type": "top-scope",
+      "line": 3,
+      "col": 4,
+      "expected": "support.function.directive.cowel",
+      "description": "New splice (parens): splice directive with argument group has correct scope"
+    },
+    {
+      "type": "top-scope",
+      "line": 3,
+      "col": 6,
+      "expected": "punctuation.section.arguments.begin.cowel",
+      "description": "New splice (parens): opening parenthesis after splice directive is highlighted"
+    },
+    {
+      "type": "top-scope",
+      "line": 3,
+      "col": 7,
+      "expected": "constant.numeric.integer.decimal.cowel",
+      "description": "New splice (parens): numeric literal inside splice argument group is highlighted"
+    },
+    {
+      "type": "top-scope",
+      "line": 3,
+      "col": 10,
+      "expected": "punctuation.section.arguments.end.cowel",
+      "description": "New splice (parens): closing parenthesis after splice directive is highlighted"
+    },
+    {
+      "type": "token-has-scope",
+      "line": 3,
+      "col": 4,
+      "scope": "string.quoted.double.cowel",
+      "description": "New splice (parens): splice directive in line still has string parent scope"
     }
   ]
 }


### PR DESCRIPTION
<img width="258" height="130" alt="image" src="https://github.com/user-attachments/assets/eefd5890-d5f0-4bcf-842c-b2d96cec7eae" />

This fixes two issues with highlighting parentheses and braces inside of strings:
1. The selected scope is not correct. Something wrong about `\G`, but to be honest I still don't fully understand what `\G` would have matched anyway.
2. Without specifying a token type for brackets, the token type applied by strings (`string`) still applies and prevents paired bracket highlighting.