### PR TITLE
Exclude ghost code, delete dead code

### DIFF
--- a/engine/include/cowel/ast.hpp
+++ b/engine/include/cowel/ast.hpp
@@ -101,28 +101,6 @@ constexpr bool primary_kind_is_spliceable_value(Primary_Kind kind)
     return primary_kind_is_value(kind) && primary_kind_is_spliceable(kind);
 }
 
-[[nodiscard]]
-constexpr std::u8string_view primary_kind_display_name(Primary_Kind kind)
-{
-    using enum Primary_Kind;
-    switch (kind) {
-    case unit_literal: return u8"unit";
-    case null_literal: return u8"null";
-    case bool_literal: return u8"boolean literal";
-    case int_literal: return u8"integer literal";
-    case decimal_float_literal: return u8"floating-point literal";
-    case infinity: return u8"infinity";
-    case unquoted_string: return u8"unquoted string";
-    case text: return u8"text";
-    case escape: return u8"escape";
-    case comment: return u8"comment";
-    case quoted_string: return u8"quoted string";
-    case block: return u8"block";
-    case group: return u8"group";
-    }
-    COWEL_ASSERT_UNREACHABLE(u8"Invalid kind.");
-}
-
 enum struct Float_Literal_Status : Default_Underlying {
     /// @brief `value` holds the (possibly rounded) value.
     ok,

--- a/engine/include/cowel/util/math.hpp
+++ b/engine/include/cowel/util/math.hpp
@@ -184,32 +184,12 @@ constexpr bool mul_overflow(Int128& out, const Int128 x, const Int128 y) noexcep
     return __builtin_mul_overflow(x, y, &out);
 }
 
-inline float roundeven(float x) noexcept
-{
-#if __has_builtin(__builtin_roundevenf)
-    return __builtin_roundevenf(x);
-#else
-    return ::roundevenf(x);
-#endif
-}
-
 inline double roundeven(double x) noexcept
 {
 #if __has_builtin(__builtin_roundeven)
     return __builtin_roundeven(x);
 #else
     return ::roundeven(x);
-#endif
-}
-
-inline float fminimum(float x, float y) noexcept
-{
-#if __has_builtin(__builtin_wasm_min_f32)
-    return __builtin_wasm_min_f32(x, y);
-#elif __has_builtin(__builtin_fminimumf)
-    return __builtin_fminimumf(x, y);
-#else
-    return ::fminimumf(x, y);
 #endif
 }
 
@@ -221,17 +201,6 @@ inline double fminimum(double x, double y) noexcept
     return __builtin_fminimum(x, y);
 #else
     return ::fminimum(x, y);
-#endif
-}
-
-inline float fmaximum(float x, float y) noexcept
-{
-#if __has_builtin(__builtin_wasm_max_f32)
-    return __builtin_wasm_max_f32(x, y);
-#elif __has_builtin(__builtin_fmaximumf)
-    return __builtin_fmaximumf(x, y);
-#else
-    return ::fmaximumf(x, y);
 #endif
 }
 

--- a/tools/filter-lcov.py
+++ b/tools/filter-lcov.py
@@ -32,8 +32,13 @@ def excluded_lines_for_file(file_path: Path) -> set[int]:
             excluded.add(index)
             continue
 
-        # Treat explicit unreachable assertion helpers as excluded coverage lines.
-        if "COWEL_ASSERT_UNREACHABLE(" in line or "COWEL_DEBUG_ASSERT_UNREACHABLE(" in line:
+        # This is a common pattern that immediately leads to unreachable code,
+        # so should treat it like the assertion it jumps into.
+        if "default: break;" in line:
+            excluded.add(index)
+
+        # Treat assertions as ghost code.
+        if "COWEL_ASSERT" in line or "COWEL_DEBUG_ASSERT" in line:
             excluded.add(index)
 
     return excluded


### PR DESCRIPTION
This change excludes all `COWEL_ASSERT` uses from coverage in any way. These are ghost code, and it doesn't make sense to count them in any way.

There is also some obvious dead code which should just be removed to increase coverage.