### PR TITLE
Refactor evaluation of binary expressions

### DIFF
--- a/engine/include/cowel/builtin_directive_set.hpp
+++ b/engine/include/cowel/builtin_directive_set.hpp
@@ -448,12 +448,14 @@ public:
 
 struct Comparison_Expression_Behavior final : Bool_Directive_Behavior {
 private:
-    const Comparison_Expression_Kind m_expression_kind;
+    const Comparison_Expression_Kind m_comparison_kind;
+    const Binary_Expression_Kind m_binary_kind
+        = comparison_kind_binary_expression_kind(m_comparison_kind);
 
 public:
     [[nodiscard]]
     constexpr explicit Comparison_Expression_Behavior(Comparison_Expression_Kind kind)
-        : m_expression_kind { kind }
+        : m_comparison_kind { kind }
     {
     }
 

--- a/engine/include/cowel/directive_processing.hpp
+++ b/engine/include/cowel/directive_processing.hpp
@@ -225,19 +225,22 @@ Result<Value, Processing_Status> evaluate_unary(
     Context& context
 );
 
+/// @brief Checks whether `lhs` and `rhs` are correct types for the given `kind` of expression,
+/// and returns the concrete `Builtin_Operation_Kind` if so.
+/// Otherwise, returns `Processing_Status::error` and outputs a diagnostic.
 [[nodiscard]]
-Result<bool, Processing_Status> evaluate_comparison(
-    Comparison_Expression_Kind kind,
-    const Value& lhs,
-    const Value& rhs,
+Result<Builtin_Operation_Kind, Processing_Status> check_operation(
+    Binary_Expression_Kind kind,
+    const Type& lhs,
+    const Type& rhs,
     const File_Source_Span& lhs_location,
     const File_Source_Span& rhs_location,
     Context& context
 );
 
 [[nodiscard]]
-Result<Value, Processing_Status> evaluate_binary_numeric(
-    Binary_Expression_Kind kind,
+Result<Value, Processing_Status> evaluate_builtin(
+    Builtin_Operation_Kind kind,
     const Value& lhs,
     const Value& rhs,
     const File_Source_Span& lhs_location,

--- a/engine/include/cowel/parameters.hpp
+++ b/engine/include/cowel/parameters.hpp
@@ -326,7 +326,7 @@ public:
     ) = 0;
 
     /// @brief Returns the type of value that is accepted by this matcher.
-    /// This i possibly a union in the case of several types.
+    /// This is possibly a union in the case of several types.
     [[nodiscard]]
     const Type& get_matchable_type() const
     {

--- a/engine/include/cowel/parameters.hpp
+++ b/engine/include/cowel/parameters.hpp
@@ -325,8 +325,10 @@ public:
         const Match_Fail_Options& on_fail
     ) = 0;
 
+    /// @brief Returns the type of value that is accepted by this matcher.
+    /// This i possibly a union in the case of several types.
     [[nodiscard]]
-    const Type& get_type() const
+    const Type& get_matchable_type() const
     {
         return m_type;
     }
@@ -819,7 +821,7 @@ public:
     [[nodiscard]]
     const Type& get_type() const
     {
-        return m_value_matcher.get_type();
+        return m_value_matcher.get_matchable_type();
     }
 };
 

--- a/engine/include/cowel/syntax/expression_kind.hpp
+++ b/engine/include/cowel/syntax/expression_kind.hpp
@@ -1,5 +1,7 @@
-#ifndef COWEL_EXPRESSION_KIND
-#define COWEL_EXPRESSION_KIND
+#ifndef COWEL_EXPRESSION_KIND_HPP
+#define COWEL_EXPRESSION_KIND_HPP
+
+#include "cowel/util/assert.hpp"
 
 #include "cowel/fwd.hpp"
 
@@ -35,6 +37,75 @@ enum struct Binary_Expression_Kind : Default_Underlying {
     multiply,
     divide,
     remainder,
+};
+
+[[nodiscard]]
+constexpr Binary_Expression_Kind
+comparison_kind_binary_expression_kind(const Comparison_Expression_Kind kind)
+{
+    using enum Comparison_Expression_Kind;
+    switch (kind) {
+    case eq: return Binary_Expression_Kind::eq;
+    case ne: return Binary_Expression_Kind::ne;
+    case lt: return Binary_Expression_Kind::lt;
+    case gt: return Binary_Expression_Kind::gt;
+    case le: return Binary_Expression_Kind::le;
+    case ge: return Binary_Expression_Kind::ge;
+    }
+    COWEL_ASSERT_UNREACHABLE(u8"Invalid comparison kind.");
+}
+
+[[nodiscard]]
+constexpr Comparison_Expression_Kind
+binary_expression_kind_comparison_kind(const Binary_Expression_Kind kind)
+{
+    using enum Binary_Expression_Kind;
+    switch (kind) {
+    case eq: return Comparison_Expression_Kind::eq;
+    case ne: return Comparison_Expression_Kind::ne;
+    case lt: return Comparison_Expression_Kind::lt;
+    case gt: return Comparison_Expression_Kind::gt;
+    case le: return Comparison_Expression_Kind::le;
+    case ge: return Comparison_Expression_Kind::ge;
+    default: break;
+    }
+    COWEL_ASSERT_UNREACHABLE(u8"Expression kind is not a comparison.");
+}
+
+enum struct Builtin_Operation_Kind : Default_Underlying {
+    tautology,
+    contradiction,
+    logical_or_bool_bool,
+    logical_and_bool_bool,
+    eq_bool_bool,
+    eq_int_int,
+    eq_float_float,
+    eq_str_str,
+    eq_dynamic_groups,
+    ne_bool_bool,
+    ne_int_int,
+    ne_float_float,
+    ne_str_str,
+    lt_int_int,
+    lt_float_float,
+    lt_str_str,
+    gt_int_int,
+    gt_float_float,
+    gt_str_str,
+    le_int_int,
+    le_float_float,
+    le_str_str,
+    ge_int_int,
+    ge_float_float,
+    ge_str_str,
+    plus_int_int,
+    plus_float_float,
+    minus_int_int,
+    minus_float_float,
+    multiply_int_int,
+    multiply_float_float,
+    div_float_float,
+    rem_to_zero_int_int,
 };
 
 }; // namespace cowel

--- a/engine/include/cowel/type.hpp
+++ b/engine/include/cowel/type.hpp
@@ -403,12 +403,12 @@ public:
         return *this == other;
     }
 
-    /// @brief Returns `true` if this type is analytically convertible to `other`.
+    /// @brief Returns `true` if this type is an instance of `other`.
     /// That is, if this type is equivalent to `other` or if an expression of this type
     /// could be stored in a variable of type `other` without any change to that value.
     ///
-    /// For example, `int` is analytically convertible to `int | null`,
-    /// and `nothing` is analytically convertible to any other type.
+    /// For example, `int` is an instance of `int | null`,
+    /// and `nothing` is an instance of any other type.
     [[nodiscard]]
     constexpr bool instance_of(const Type& other) const
     {

--- a/engine/include/cowel/type.hpp
+++ b/engine/include/cowel/type.hpp
@@ -410,7 +410,7 @@ public:
     /// For example, `int` is analytically convertible to `int | null`,
     /// and `nothing` is analytically convertible to any other type.
     [[nodiscard]]
-    constexpr bool analytically_convertible_to(const Type& other) const
+    constexpr bool instance_of(const Type& other) const
     {
         COWEL_ASSERT(is_canonical());
         COWEL_ASSERT(other.is_canonical());
@@ -425,15 +425,15 @@ public:
         }
         case Type_Kind::pack: {
             return other.m_kind == Type_Kind::pack
-                && m_members.front().analytically_convertible_to(other.m_members.front());
+                && m_members.front().instance_of(other.m_members.front());
         }
         case Type_Kind::named: {
             return other.m_kind == Type_Kind::named
-                && m_members.front().analytically_convertible_to(other.m_members.front());
+                && m_members.front().instance_of(other.m_members.front());
         }
         case Type_Kind::union_: {
             return std::ranges::all_of(m_members, [&](const Type& type) {
-                return type.analytically_convertible_to(other);
+                return type.instance_of(other);
             });
         }
         case Type_Kind::group: {
@@ -448,7 +448,7 @@ public:
             }
             const bool all_members_convertible = [&] {
                 for (std::size_t i = 0; i < m_members.size(); ++i) {
-                    if (!m_members[i].analytically_convertible_to(other.m_members[i])) {
+                    if (!m_members[i].instance_of(other.m_members[i])) {
                         return false;
                     }
                 }
@@ -468,11 +468,11 @@ public:
         }
         case Type_Kind::lazy: {
             COWEL_ASSERT(other.m_members.size() == 1);
-            return analytically_convertible_to(other.m_members.front());
+            return instance_of(other.m_members.front());
         }
         case Type_Kind::union_: {
             return std::ranges::any_of(other.m_members, [&](const Type& type) {
-                return analytically_convertible_to(type);
+                return instance_of(type);
             });
         }
         default: break;

--- a/engine/include/cowel/value.hpp
+++ b/engine/include/cowel/value.hpp
@@ -16,14 +16,10 @@
 #include "cowel/type.hpp"
 
 #include "cowel/syntax/ast_fwd.hpp"
-#include "cowel/syntax/expression_kind.hpp"
 
 namespace cowel {
 
 struct Value;
-
-template <Comparison_Expression_Kind kind>
-bool compare(const Value&, const Value&);
 
 /// @brief A symbolic empty class indicating a `null` value or type in COWEL.
 struct Null {
@@ -482,9 +478,6 @@ public:
 
     [[nodiscard]]
     Processing_Status splice_block(Content_Policy& out, Context& context) const;
-
-    template <Comparison_Expression_Kind kind>
-    friend bool compare(const Value&, const Value&);
 };
 
 struct Group_Member_Value {
@@ -720,38 +713,6 @@ inline constexpr Value Value::empty_string = Value::static_string({}, String_Kin
 inline constexpr Value Value::unit_string = Value::static_string(u8"unit", String_Kind::ascii);
 inline constexpr Value Value::true_string = Value::static_string(u8"true", String_Kind::ascii);
 inline constexpr Value Value::false_string = Value::static_string(u8"false", String_Kind::ascii);
-
-extern template bool compare<Comparison_Expression_Kind::eq>(const Value&, const Value&);
-extern template bool compare<Comparison_Expression_Kind::ne>(const Value&, const Value&);
-extern template bool compare<Comparison_Expression_Kind::lt>(const Value&, const Value&);
-extern template bool compare<Comparison_Expression_Kind::gt>(const Value&, const Value&);
-extern template bool compare<Comparison_Expression_Kind::le>(const Value&, const Value&);
-extern template bool compare<Comparison_Expression_Kind::ge>(const Value&, const Value&);
-
-inline bool compare_eq(const Value& x, const Value& y)
-{
-    return compare<Comparison_Expression_Kind::eq>(x, y);
-}
-inline bool compare_ne(const Value& x, const Value& y)
-{
-    return compare<Comparison_Expression_Kind::ne>(x, y);
-}
-inline bool compare_lt(const Value& x, const Value& y)
-{
-    return compare<Comparison_Expression_Kind::lt>(x, y);
-}
-inline bool compare_gt(const Value& x, const Value& y)
-{
-    return compare<Comparison_Expression_Kind::gt>(x, y);
-}
-inline bool compare_le(const Value& x, const Value& y)
-{
-    return compare<Comparison_Expression_Kind::le>(x, y);
-}
-inline bool compare_ge(const Value& x, const Value& y)
-{
-    return compare<Comparison_Expression_Kind::ge>(x, y);
-}
 
 } // namespace cowel
 

--- a/engine/src/directive_processing.cpp
+++ b/engine/src/directive_processing.cpp
@@ -675,64 +675,17 @@ evaluate(const ast::Binary_Expression& expression, const Frame_Index frame, Cont
     const Value& lhs = *lhs_result;
     const Value& rhs = *rhs_result;
 
-    switch (kind) {
-    case Binary_Expression_Kind::eq: {
-        const auto r
-            = evaluate_comparison(Comparison_Expression_Kind::eq, lhs, rhs, span, span, context);
-        if (!r) {
-            return r.error();
-        }
-        return Value::boolean(*r);
+    const Result<Builtin_Operation_Kind, Processing_Status> operation = check_operation(
+        kind, lhs.get_type(), rhs.get_type(), expression.get_lhs().get_source_span(),
+        expression.get_rhs().get_source_span(), context
+    );
+    if (!operation) {
+        return operation.error();
     }
-    case Binary_Expression_Kind::ne: {
-        const auto r
-            = evaluate_comparison(Comparison_Expression_Kind::ne, lhs, rhs, span, span, context);
-        if (!r) {
-            return r.error();
-        }
-        return Value::boolean(*r);
-    }
-    case Binary_Expression_Kind::lt: {
-        const auto r
-            = evaluate_comparison(Comparison_Expression_Kind::lt, lhs, rhs, span, span, context);
-        if (!r) {
-            return r.error();
-        }
-        return Value::boolean(*r);
-    }
-    case Binary_Expression_Kind::gt: {
-        const auto r
-            = evaluate_comparison(Comparison_Expression_Kind::gt, lhs, rhs, span, span, context);
-        if (!r) {
-            return r.error();
-        }
-        return Value::boolean(*r);
-    }
-    case Binary_Expression_Kind::le: {
-        const auto r
-            = evaluate_comparison(Comparison_Expression_Kind::le, lhs, rhs, span, span, context);
-        if (!r) {
-            return r.error();
-        }
-        return Value::boolean(*r);
-    }
-    case Binary_Expression_Kind::ge: {
-        const auto r
-            = evaluate_comparison(Comparison_Expression_Kind::ge, lhs, rhs, span, span, context);
-        if (!r) {
-            return r.error();
-        }
-        return Value::boolean(*r);
-    }
-    case Binary_Expression_Kind::plus:
-    case Binary_Expression_Kind::minus:
-    case Binary_Expression_Kind::multiply:
-    case Binary_Expression_Kind::divide:
-    case Binary_Expression_Kind::remainder:
-        return evaluate_binary_numeric(kind, lhs, rhs, span, span, context);
-    default: break;
-    }
-    COWEL_ASSERT_UNREACHABLE(u8"Unhandled binary expression kind.");
+    return evaluate_builtin(
+        *operation, lhs, rhs, expression.get_lhs().get_source_span(),
+        expression.get_rhs().get_source_span(), context
+    );
 }
 
 Result<Value, Processing_Status> evaluate_unary(

--- a/engine/src/directives/variables.cpp
+++ b/engine/src/directives/variables.cpp
@@ -187,8 +187,7 @@ struct Logical_Expression_Evaluator {
         for (const Argument& member : arguments) {
             COWEL_ASSERT(member.is_positional());
             const Type& static_type = member.get_static_type(context);
-            if (static_type != Type::any
-                && !static_type.analytically_convertible_to(Type::boolean)) {
+            if (static_type != Type::any && !static_type.instance_of(Type::boolean)) {
                 return type_error(static_type, member.get_value_location());
             }
             const Result<Value, Processing_Status> member_result = member.evaluate(frame, context);
@@ -236,7 +235,7 @@ Comparison_Expression_Behavior::do_evaluate(const Invocation& call, Context& con
     static constexpr Type relation_comparable_types[] { Type::integer, Type::floating, Type::str };
     static constexpr auto relation_comparable = Type::union_of(relation_comparable_types);
     static_assert(relation_comparable.is_canonical());
-    const auto& parameter_type = m_expression_kind <= Comparison_Expression_Kind::ne
+    const auto& parameter_type = m_comparison_kind <= Comparison_Expression_Kind::ne
         ? equality_comparable
         : relation_comparable;
 
@@ -251,10 +250,19 @@ Comparison_Expression_Behavior::do_evaluate(const Invocation& call, Context& con
         return match_status;
     }
 
-    return evaluate_comparison(
-        m_expression_kind, x_value.get(), y_value.get(), x_value.get_location(),
-        y_value.get_location(), context
+    const Value& x = x_value.get();
+    const Value& y = y_value.get();
+
+    const Result<Builtin_Operation_Kind, Processing_Status> operation = check_operation(
+        m_binary_kind, x.get_type(), y.get_type(), x_value.get_location(), y_value.get_location(),
+        context
     );
+    // Checks on the directive should have prevented a failure here.
+    COWEL_ASSERT(operation);
+    const Result<Value, Processing_Status> result = evaluate_builtin(
+        *operation, x, y, x_value.get_location(), y_value.get_location(), context
+    );
+    return result->as_boolean();
 }
 
 Result<bool, Processing_Status>
@@ -299,7 +307,32 @@ Internal_Eq_Behavior::do_evaluate(const Invocation& call, Context& context) cons
         return Processing_Status::error;
     }
 
-    return compare<Comparison_Expression_Kind::eq>(x, y);
+    if (x.get_type_kind() == Type_Kind::group) {
+        const auto result = evaluate_builtin(
+            Builtin_Operation_Kind::eq_dynamic_groups, x, y, x_value.get_location(),
+            y_value.get_location(), context
+        );
+        if (!result) {
+            return result.error();
+        }
+        return result->as_boolean();
+    }
+
+    const auto operation = check_operation(
+        Binary_Expression_Kind::eq, x.get_type(), y.get_type(), x_value.get_location(),
+        y_value.get_location(), context
+    );
+    if (!operation) {
+        return operation.error();
+    }
+
+    const auto result = evaluate_builtin(
+        *operation, x, y, x_value.get_location(), y_value.get_location(), context
+    );
+    if (!result) {
+        return result.error();
+    }
+    return result->as_boolean();
 }
 
 Result<Value, Processing_Status>
@@ -396,7 +429,7 @@ N_Ary_Numeric_Expression_Behavior::evaluate(const Invocation& call, Context& con
             }
         }
         else {
-            if (!value.get_type().analytically_convertible_to(numeric_type)) {
+            if (!value.get_type().instance_of(numeric_type)) {
                 context.try_error(
                     diagnostic::type_mismatch, location,
                     joined_char_sequence(

--- a/engine/src/directives/variables.cpp
+++ b/engine/src/directives/variables.cpp
@@ -257,11 +257,15 @@ Comparison_Expression_Behavior::do_evaluate(const Invocation& call, Context& con
         m_binary_kind, x.get_type(), y.get_type(), x_value.get_location(), y_value.get_location(),
         context
     );
-    // Checks on the directive should have prevented a failure here.
-    COWEL_ASSERT(operation);
+    if (!operation) {
+        return operation.error();
+    }
     const Result<Value, Processing_Status> result = evaluate_builtin(
         *operation, x, y, x_value.get_location(), y_value.get_location(), context
     );
+    // The operation is a comparison,
+    // so there's no way it could have failed,
+    // e.g. through division by zero.
     return result->as_boolean();
 }
 

--- a/engine/src/parameters.cpp
+++ b/engine/src/parameters.cpp
@@ -99,13 +99,13 @@ Processing_Status Lazy_Value_Of_Type_Matcher::match_value(
     const Type& actual_type = argument.get_static_type(context);
     COWEL_DEBUG_ASSERT(actual_type.is_canonical());
 
-    if (actual_type != Type::any && !actual_type.analytically_convertible_to(get_type())) {
+    if (actual_type != Type::any && !actual_type.instance_of(get_matchable_type())) {
         on_fail.emit(
             argument.get_value_location(),
             joined_char_sequence(
                 {
                     u8"Expected a value of type "sv,
-                    get_type().get_display_name(),
+                    get_matchable_type().get_display_name(),
                     u8", but got "sv,
                     actual_type.get_display_name(),
                     u8".",
@@ -131,13 +131,13 @@ Processing_Status Value_Of_Type_Matcher::match_value(
     if (!val) {
         return status_max(val.error(), on_fail.status);
     }
-    if (!val->get_type().analytically_convertible_to(get_type())) {
+    if (!val->get_type().instance_of(get_matchable_type())) {
         on_fail.emit(
             argument.get_value_location(),
             joined_char_sequence(
                 {
                     u8"Expected a value of type "sv,
-                    get_type().get_display_name(),
+                    get_matchable_type().get_display_name(),
                     u8", but got "sv,
                     val->get_type().get_display_name(),
                     u8".",
@@ -344,9 +344,9 @@ Processing_Status Pack_Of_Type_Matcher::match_value(
     if (!val) {
         return status_max(val.error(), on_fail.status);
     }
-    COWEL_DEBUG_ASSERT(get_type().is_pack());
-    const Type& element_type = get_type().get_members().front();
-    if (!val->get_type().analytically_convertible_to(element_type)) {
+    COWEL_DEBUG_ASSERT(get_matchable_type().is_pack());
+    const Type& element_type = get_matchable_type().get_members().front();
+    if (!val->get_type().instance_of(element_type)) {
         on_fail.emit(
             argument.get_value_location(),
             joined_char_sequence(
@@ -373,7 +373,7 @@ Processing_Status Pack_Named_Of_Type_Matcher::match_value(
     const Match_Fail_Options& on_fail
 )
 {
-    COWEL_DEBUG_ASSERT(get_type().is_pack());
+    COWEL_DEBUG_ASSERT(get_matchable_type().is_pack());
 
     if (!argument.is_named()) {
         on_fail.emit(
@@ -389,7 +389,7 @@ Processing_Status Pack_Named_Of_Type_Matcher::match_value(
         return status_max(val.error(), on_fail.status);
     }
 
-    if (!val->get_type().analytically_convertible_to(m_element_type)) {
+    if (!val->get_type().instance_of(m_element_type)) {
         on_fail.emit(
             argument.get_value_location(),
             joined_char_sequence(
@@ -587,7 +587,7 @@ Processing_Status Match_Call::operator()(
                 if (arg_status != Processing_Status::ok) {
                     return arg_status;
                 }
-                if (value_matcher.get_type().is_pack()) {
+                if (value_matcher.get_matchable_type().is_pack()) {
                     mode = Argument_Mode::pack_positional;
                     current_pack_param_index = parameter_index;
                     current_pack_value_matcher = &value_matcher;

--- a/engine/src/semantics.cpp
+++ b/engine/src/semantics.cpp
@@ -144,43 +144,81 @@ Value Value::group_pack_move(std::span<Value> values)
 
 namespace {
 
-template <Comparison_Expression_Kind kind, typename T, typename U>
-bool do_compare(const T& x, const U& y)
+[[nodiscard]]
+Result<bool, Processing_Status> evaluate_internal_equality(
+    const Value& lhs,
+    const Value& rhs,
+    const File_Source_Span& lhs_location,
+    const File_Source_Span& rhs_location,
+    Context& context
+)
 {
-    if constexpr (kind == Comparison_Expression_Kind::eq) {
-        return x == y;
+    using enum Builtin_Operation_Kind;
+
+    if (lhs.get_type_kind() != rhs.get_type_kind()) {
+        return false;
     }
-    else if constexpr (kind == Comparison_Expression_Kind::ne) {
-        return x != y;
+
+    switch (lhs.get_type_kind()) {
+    case Type_Kind::unit:
+    case Type_Kind::null:
+    case Type_Kind::boolean:
+    case Type_Kind::integer:
+    case Type_Kind::floating:
+    case Type_Kind::str: {
+        const auto operation = check_operation(
+            Binary_Expression_Kind::eq, lhs.get_type(), rhs.get_type(), lhs_location, rhs_location,
+            context
+        );
+        if (!operation) {
+            return operation.error();
+        }
+        const auto result
+            = evaluate_builtin(*operation, lhs, rhs, lhs_location, rhs_location, context);
+        if (!result) {
+            return result.error();
+        }
+        return result->as_boolean();
     }
-    else if constexpr (kind == Comparison_Expression_Kind::lt) {
-        return x < y;
+
+    case Type_Kind::group: {
+        const auto result
+            = evaluate_builtin(eq_dynamic_groups, lhs, rhs, lhs_location, rhs_location, context);
+        if (!result) {
+            return result.error();
+        }
+        return result->as_boolean();
     }
-    else if constexpr (kind == Comparison_Expression_Kind::gt) {
-        return x > y;
+
+    default: break;
     }
-    else if constexpr (kind == Comparison_Expression_Kind::le) {
-        return x <= y;
-    }
-    else if constexpr (kind == Comparison_Expression_Kind::ge) {
-        return x >= y;
-    }
-    else {
-        static_assert(false);
-    }
+
+    COWEL_ASSERT_UNREACHABLE(u8"Invalid type in internal equality.");
 }
 
-[[/* false positive */ maybe_unused]] bool
-members_equal(std::span<const Group_Member_Value> xs, std::span<const Group_Member_Value> ys)
+bool members_equal(
+    std::span<const Group_Member_Value> xs,
+    std::span<const Group_Member_Value> ys,
+    const File_Source_Span& lhs_location,
+    const File_Source_Span& rhs_location,
+    Context& context
+)
 {
     if (xs.size() != ys.size()) {
         return false;
     }
     for (std::size_t i = 0; i < xs.size(); ++i) {
-        if (!compare<Comparison_Expression_Kind::eq>(xs[i].name, ys[i].name)) {
+        const auto name_equal = evaluate_internal_equality(
+            xs[i].name, ys[i].name, lhs_location, rhs_location, context
+        );
+        if (!name_equal || !*name_equal) {
             return false;
         }
-        if (!compare<Comparison_Expression_Kind::eq>(xs[i].value, ys[i].value)) {
+
+        const auto value_equal = evaluate_internal_equality(
+            xs[i].value, ys[i].value, lhs_location, rhs_location, context
+        );
+        if (!value_equal || !*value_equal) {
             return false;
         }
     }
@@ -188,57 +226,6 @@ members_equal(std::span<const Group_Member_Value> xs, std::span<const Group_Memb
 }
 
 } // namespace
-
-template <Comparison_Expression_Kind kind>
-bool compare(const Value& x, const Value& y)
-{
-    switch (x.get_type_kind()) {
-    case Type_Kind::unit:
-    case Type_Kind::null: {
-        if constexpr (kind == Comparison_Expression_Kind::eq) {
-            return true;
-        }
-        else if constexpr (kind == Comparison_Expression_Kind::ne) {
-            return false;
-        }
-        else {
-            COWEL_ASSERT_UNREACHABLE(u8"Relational comparison of unit types?!");
-        }
-    }
-    case Type_Kind::boolean: {
-        return do_compare<kind>(x.as_boolean(), y.as_boolean());
-    }
-    case Type_Kind::integer: {
-        return do_compare<kind>(x.as_integer(), y.as_integer());
-    }
-    case Type_Kind::floating: {
-        return do_compare<kind>(x.as_float(), y.as_float());
-    }
-    case Type_Kind::str: {
-        return do_compare<kind>(x.as_string(), y.as_string());
-    }
-    case Type_Kind::group: {
-        if constexpr (kind == Comparison_Expression_Kind::eq) {
-            return members_equal(x.get_group_members(), y.get_group_members());
-        }
-        else if constexpr (kind == Comparison_Expression_Kind::ne) {
-            return !members_equal(x.get_group_members(), y.get_group_members());
-        }
-        else {
-            COWEL_ASSERT_UNREACHABLE(u8"Relational comparison of unit types?!");
-        }
-    }
-    default: break;
-    }
-    COWEL_ASSERT_UNREACHABLE(u8"Invalid type in comparison.");
-}
-
-template bool compare<Comparison_Expression_Kind::eq>(const Value&, const Value&);
-template bool compare<Comparison_Expression_Kind::ne>(const Value&, const Value&);
-template bool compare<Comparison_Expression_Kind::lt>(const Value&, const Value&);
-template bool compare<Comparison_Expression_Kind::gt>(const Value&, const Value&);
-template bool compare<Comparison_Expression_Kind::le>(const Value&, const Value&);
-template bool compare<Comparison_Expression_Kind::ge>(const Value&, const Value&);
 
 static_assert(sizeof(Int32) == 4);
 static_assert(sizeof(Int64) == 8);
@@ -278,16 +265,82 @@ consteval bool test_sanitized()
 
 static_assert(test_sanitized());
 
-Result<bool, Processing_Status> evaluate_comparison(
-    const Comparison_Expression_Kind kind,
-    const Value& lhs,
-    const Value& rhs,
+namespace {
+
+[[nodiscard]]
+bool expect_type(
+    const Type& actual,
+    const Type& expected,
+    const File_Source_Span& error_location,
+    Context& context
+)
+{
+    if (actual.instance_of(expected)) {
+        return true;
+    }
+    context.try_error(
+        diagnostic::type_mismatch, error_location,
+        joined_char_sequence(
+            {
+                u8"Expected a value of type "sv,
+                expected.get_display_name(),
+                u8", but got "sv,
+                actual.get_display_name(),
+                u8".",
+            }
+        )
+    );
+    return false;
+}
+
+[[nodiscard]]
+bool expect_types_homogeneous(
+    const Type& lhs,
+    const Type& rhs,
+    const Type& type,
     const File_Source_Span& lhs_location,
     const File_Source_Span& rhs_location,
     Context& context
 )
 {
-    using namespace std::string_view_literals;
+    if (!expect_type(lhs, type, lhs_location, context)
+        || !expect_type(rhs, type, rhs_location, context)) {
+        return false;
+    }
+    if (lhs != rhs) {
+        context.try_error(
+            diagnostic::type_mismatch, rhs_location,
+            joined_char_sequence(
+                {
+                    u8"Both operands must be of the same type, but left-hand side is "sv,
+                    lhs.get_display_name(),
+                    u8" and right-hand side is "sv,
+                    rhs.get_display_name(),
+                    u8".",
+                }
+            )
+        );
+        return false;
+    }
+    return true;
+}
+
+} // namespace
+
+Result<Builtin_Operation_Kind, Processing_Status> check_operation(
+    const Binary_Expression_Kind kind,
+    const Type& lhs,
+    const Type& rhs,
+    const File_Source_Span& lhs_location,
+    const File_Source_Span& rhs_location,
+    Context& context
+)
+{
+    // Can't do proper type checking on analytical types like unions, any, etc.
+    COWEL_ASSERT(type_kind_is_value_holdable(lhs.get_kind()));
+    COWEL_ASSERT(type_kind_is_value_holdable(rhs.get_kind()));
+
+    using enum Builtin_Operation_Kind;
 
     static constexpr Type equality_comparable_types[] {
         Type::unit, Type::null, Type::boolean, Type::integer, Type::floating, Type::str,
@@ -299,156 +352,305 @@ Result<bool, Processing_Status> evaluate_comparison(
     static constexpr auto relation_comparable = Type::union_of(relation_comparable_types);
     static_assert(relation_comparable.is_canonical());
 
-    const auto& acceptable_type
-        = kind <= Comparison_Expression_Kind::ne ? equality_comparable : relation_comparable;
-
-    bool ok = true;
-    if (!lhs.get_type().analytically_convertible_to(acceptable_type)) {
-        context.try_error(
-            diagnostic::type_mismatch, lhs_location,
-            joined_char_sequence(
-                {
-                    u8"Expected a value of type "sv,
-                    acceptable_type.get_display_name(),
-                    u8", but got "sv,
-                    lhs.get_type().get_display_name(),
-                    u8".",
-                }
-            )
-        );
-        ok = false;
-    }
-    if (!rhs.get_type().analytically_convertible_to(acceptable_type)) {
-        context.try_error(
-            diagnostic::type_mismatch, rhs_location,
-            joined_char_sequence(
-                {
-                    u8"Expected a value of type "sv,
-                    acceptable_type.get_display_name(),
-                    u8", but got "sv,
-                    rhs.get_type().get_display_name(),
-                    u8".",
-                }
-            )
-        );
-        ok = false;
-    }
-    if (!ok) {
-        return Processing_Status::error;
-    }
-    if (lhs.get_type() != rhs.get_type()) {
-        context.try_error(
-            diagnostic::type_mismatch, rhs_location,
-            joined_char_sequence(
-                {
-                    u8"Cannot compare values of different type; that is, cannot compare "sv,
-                    rhs.get_type().get_display_name(),
-                    u8" with left-hand-side type "sv,
-                    lhs.get_type().get_display_name(),
-                    u8".",
-                }
-            )
-        );
-        return Processing_Status::error;
-    }
+    static constexpr Type numeric_types[] { Type::integer, Type::floating };
+    static constexpr auto numeric_type = Type::union_of(numeric_types);
+    static_assert(numeric_type.is_canonical());
 
     switch (kind) {
-    case Comparison_Expression_Kind::eq: return compare<Comparison_Expression_Kind::eq>(lhs, rhs);
-    case Comparison_Expression_Kind::ne: return compare<Comparison_Expression_Kind::ne>(lhs, rhs);
-    case Comparison_Expression_Kind::lt: return compare<Comparison_Expression_Kind::lt>(lhs, rhs);
-    case Comparison_Expression_Kind::gt: return compare<Comparison_Expression_Kind::gt>(lhs, rhs);
-    case Comparison_Expression_Kind::le: return compare<Comparison_Expression_Kind::le>(lhs, rhs);
-    case Comparison_Expression_Kind::ge: return compare<Comparison_Expression_Kind::ge>(lhs, rhs);
+    case Binary_Expression_Kind::logical_or: {
+        if (!expect_types_homogeneous(
+                lhs, rhs, Type::boolean, lhs_location, rhs_location, context
+            )) {
+            return Processing_Status::error;
+        }
+        return logical_or_bool_bool;
     }
-    COWEL_ASSERT_UNREACHABLE(u8"Invalid comparison kind.");
+    case Binary_Expression_Kind::logical_and: {
+        if (!expect_types_homogeneous(
+                lhs, rhs, Type::boolean, lhs_location, rhs_location, context
+            )) {
+            return Processing_Status::error;
+        }
+        return logical_and_bool_bool;
+    }
+    case Binary_Expression_Kind::eq: {
+        if (!expect_types_homogeneous(
+                lhs, rhs, equality_comparable, lhs_location, rhs_location, context
+            )) {
+            return Processing_Status::error;
+        }
+        switch (lhs.get_kind()) {
+        case Type_Kind::unit:
+        case Type_Kind::null: return tautology;
+        case Type_Kind::boolean: return eq_bool_bool;
+        case Type_Kind::integer: return eq_int_int;
+        case Type_Kind::floating: return eq_float_float;
+        case Type_Kind::str: return eq_str_str;
+        default: break;
+        }
+        COWEL_ASSERT_UNREACHABLE(u8"Validated type not in equality_comparable?!");
+    }
+    case Binary_Expression_Kind::ne: {
+        if (!expect_types_homogeneous(
+                lhs, rhs, equality_comparable, lhs_location, rhs_location, context
+            )) {
+            return Processing_Status::error;
+        }
+        switch (lhs.get_kind()) {
+        case Type_Kind::unit:
+        case Type_Kind::null: return contradiction;
+        case Type_Kind::boolean: return ne_bool_bool;
+        case Type_Kind::integer: return ne_int_int;
+        case Type_Kind::floating: return ne_float_float;
+        case Type_Kind::str: return ne_str_str;
+        default: break;
+        }
+        COWEL_ASSERT_UNREACHABLE(u8"Validated type not in equality_comparable?!");
+    }
+    case Binary_Expression_Kind::lt:
+    case Binary_Expression_Kind::gt:
+    case Binary_Expression_Kind::le:
+    case Binary_Expression_Kind::ge: {
+        if (!expect_types_homogeneous(
+                lhs, rhs, relation_comparable, lhs_location, rhs_location, context
+            )) {
+            return Processing_Status::error;
+        }
+        switch (lhs.get_kind()) {
+        case Type_Kind::integer:
+            switch (kind) {
+            case Binary_Expression_Kind::lt: return lt_int_int;
+            case Binary_Expression_Kind::gt: return gt_int_int;
+            case Binary_Expression_Kind::le: return le_int_int;
+            case Binary_Expression_Kind::ge: return ge_int_int;
+            default: break;
+            }
+            break;
+        case Type_Kind::floating:
+            switch (kind) {
+            case Binary_Expression_Kind::lt: return lt_float_float;
+            case Binary_Expression_Kind::gt: return gt_float_float;
+            case Binary_Expression_Kind::le: return le_float_float;
+            case Binary_Expression_Kind::ge: return ge_float_float;
+            default: break;
+            }
+            break;
+        case Type_Kind::str:
+            switch (kind) {
+            case Binary_Expression_Kind::lt: return lt_str_str;
+            case Binary_Expression_Kind::gt: return gt_str_str;
+            case Binary_Expression_Kind::le: return le_str_str;
+            case Binary_Expression_Kind::ge: return ge_str_str;
+            default: break;
+            }
+            break;
+        default: break;
+        }
+        COWEL_ASSERT_UNREACHABLE(u8"Validated type not in relation_comparable?!");
+    }
+
+    case Binary_Expression_Kind::plus: {
+        if (!expect_types_homogeneous(
+                lhs, rhs, numeric_type, lhs_location, rhs_location, context
+            )) {
+            return Processing_Status::error;
+        }
+        switch (lhs.get_kind()) {
+        case Type_Kind::integer: return plus_int_int;
+        case Type_Kind::floating: return plus_float_float;
+        default: break;
+        }
+        COWEL_ASSERT_UNREACHABLE(u8"Validated type not in numeric_type?!");
+    }
+    case Binary_Expression_Kind::minus: {
+        if (!expect_types_homogeneous(
+                lhs, rhs, numeric_type, lhs_location, rhs_location, context
+            )) {
+            return Processing_Status::error;
+        }
+        switch (lhs.get_kind()) {
+        case Type_Kind::integer: return minus_int_int;
+        case Type_Kind::floating: return minus_float_float;
+        default: break;
+        }
+        COWEL_ASSERT_UNREACHABLE(u8"Validated type not in numeric_type?!");
+    }
+    case Binary_Expression_Kind::multiply: {
+        if (!expect_types_homogeneous(
+                lhs, rhs, numeric_type, lhs_location, rhs_location, context
+            )) {
+            return Processing_Status::error;
+        }
+        switch (lhs.get_kind()) {
+        case Type_Kind::integer: return multiply_int_int;
+        case Type_Kind::floating: return multiply_float_float;
+        default: break;
+        }
+        COWEL_ASSERT_UNREACHABLE(u8"Validated type not in numeric_type?!");
+    }
+    case Binary_Expression_Kind::divide: {
+        if (!expect_types_homogeneous(
+                lhs, rhs, Type::floating, lhs_location, rhs_location, context
+            )) {
+            return Processing_Status::error;
+        }
+        return div_float_float;
+    }
+    case Binary_Expression_Kind::remainder: {
+        if (!expect_types_homogeneous(
+                lhs, rhs, Type::integer, lhs_location, rhs_location, context
+            )) {
+            return Processing_Status::error;
+        }
+        return rem_to_zero_int_int;
+    }
+    }
+
+    COWEL_ASSERT_UNREACHABLE(u8"All switch cases should have returned.");
 }
 
-Result<Value, Processing_Status> evaluate_binary_numeric(
-    const Binary_Expression_Kind kind,
+Result<Value, Processing_Status> evaluate_builtin(
+    Builtin_Operation_Kind kind,
     const Value& lhs,
     const Value& rhs,
-    const File_Source_Span& lhs_location,
+    [[maybe_unused]] const File_Source_Span& lhs_location,
     const File_Source_Span& rhs_location,
     Context& context
 )
 {
-    using namespace std::string_view_literals;
+    using enum Builtin_Operation_Kind;
 
-    // Division: float operands only.
-    if (kind == Binary_Expression_Kind::divide) {
-        bool ok = true;
-        if (!lhs.is_float()) {
-            context.try_error(
-                diagnostic::type_mismatch, lhs_location,
-                joined_char_sequence(
-                    {
-                        u8"Expected a value of type "sv,
-                        Type::floating.get_display_name(),
-                        u8", but got "sv,
-                        lhs.get_type().get_display_name(),
-                        u8".",
-                    }
-                )
-            );
-            ok = false;
-        }
-        if (!rhs.is_float()) {
-            context.try_error(
-                diagnostic::type_mismatch, rhs_location,
-                joined_char_sequence(
-                    {
-                        u8"Expected a value of type "sv,
-                        Type::floating.get_display_name(),
-                        u8", but got "sv,
-                        rhs.get_type().get_display_name(),
-                        u8".",
-                    }
-                )
-            );
-            ok = false;
-        }
-        if (!ok) {
-            return Processing_Status::error;
-        }
+    switch (kind) {
+    case tautology: {
+        return Value::true_;
+    }
+    case contradiction: {
+        return Value::false_;
+    }
+    case logical_or_bool_bool: {
+        COWEL_ASSERT(lhs.is_bool() && rhs.is_bool());
+        return Value::boolean(lhs.as_boolean() || rhs.as_boolean());
+    }
+    case logical_and_bool_bool: {
+        COWEL_ASSERT(lhs.is_bool() && rhs.is_bool());
+        return Value::boolean(lhs.as_boolean() && rhs.as_boolean());
+    }
+    case eq_bool_bool: {
+        COWEL_ASSERT(lhs.is_bool() && rhs.is_bool());
+        return Value::boolean(lhs.as_boolean() == rhs.as_boolean());
+    }
+    case eq_int_int: {
+        COWEL_ASSERT(lhs.is_int() && rhs.is_int());
+        return Value::boolean(lhs.as_integer() == rhs.as_integer());
+    }
+    case eq_float_float: {
+        COWEL_ASSERT(lhs.is_float() && rhs.is_float());
+        return Value::boolean(lhs.as_float() == rhs.as_float());
+    }
+    case eq_dynamic_groups: {
+        COWEL_ASSERT(lhs.is_group() && rhs.is_group());
+        return Value::boolean(members_equal(
+            lhs.get_group_members(), rhs.get_group_members(), lhs_location, rhs_location, context
+        ));
+    }
+    case eq_str_str: {
+        COWEL_ASSERT(lhs.is_str() && rhs.is_str());
+        return Value::boolean(lhs.as_string() == rhs.as_string());
+    }
+    case ne_bool_bool: {
+        COWEL_ASSERT(lhs.is_bool() && rhs.is_bool());
+        return Value::boolean(lhs.as_boolean() != rhs.as_boolean());
+    }
+    case ne_int_int: {
+        COWEL_ASSERT(lhs.is_int() && rhs.is_int());
+        return Value::boolean(lhs.as_integer() != rhs.as_integer());
+    }
+    case ne_float_float: {
+        COWEL_ASSERT(lhs.is_float() && rhs.is_float());
+        return Value::boolean(lhs.as_float() != rhs.as_float());
+    }
+    case ne_str_str: {
+        COWEL_ASSERT(lhs.is_str() && rhs.is_str());
+        return Value::boolean(lhs.as_string() != rhs.as_string());
+    }
+    case lt_int_int: {
+        COWEL_ASSERT(lhs.is_int() && rhs.is_int());
+        return Value::boolean(lhs.as_integer() < rhs.as_integer());
+    }
+    case lt_float_float: {
+        COWEL_ASSERT(lhs.is_float() && rhs.is_float());
+        return Value::boolean(lhs.as_float() < rhs.as_float());
+    }
+    case lt_str_str: {
+        COWEL_ASSERT(lhs.is_str() && rhs.is_str());
+        return Value::boolean(lhs.as_string() < rhs.as_string());
+    }
+    case gt_int_int: {
+        COWEL_ASSERT(lhs.is_int() && rhs.is_int());
+        return Value::boolean(lhs.as_integer() > rhs.as_integer());
+    }
+    case gt_float_float: {
+        COWEL_ASSERT(lhs.is_float() && rhs.is_float());
+        return Value::boolean(lhs.as_float() > rhs.as_float());
+    }
+    case gt_str_str: {
+        COWEL_ASSERT(lhs.is_str() && rhs.is_str());
+        return Value::boolean(lhs.as_string() > rhs.as_string());
+    }
+    case le_int_int: {
+        COWEL_ASSERT(lhs.is_int() && rhs.is_int());
+        return Value::boolean(lhs.as_integer() <= rhs.as_integer());
+    }
+    case le_float_float: {
+        COWEL_ASSERT(lhs.is_float() && rhs.is_float());
+        return Value::boolean(lhs.as_float() <= rhs.as_float());
+    }
+    case le_str_str: {
+        COWEL_ASSERT(lhs.is_str() && rhs.is_str());
+        return Value::boolean(lhs.as_string() <= rhs.as_string());
+    }
+    case ge_int_int: {
+        COWEL_ASSERT(lhs.is_int() && rhs.is_int());
+        return Value::boolean(lhs.as_integer() >= rhs.as_integer());
+    }
+    case ge_float_float: {
+        COWEL_ASSERT(lhs.is_float() && rhs.is_float());
+        return Value::boolean(lhs.as_float() >= rhs.as_float());
+    }
+    case ge_str_str: {
+        COWEL_ASSERT(lhs.is_str() && rhs.is_str());
+        return Value::boolean(lhs.as_string() >= rhs.as_string());
+    }
+    case plus_int_int: {
+        COWEL_ASSERT(lhs.is_int() && rhs.is_int());
+        return Value::integer(lhs.as_integer() + rhs.as_integer());
+    }
+    case plus_float_float: {
+        COWEL_ASSERT(lhs.is_float() && rhs.is_float());
+        return Value::floating(lhs.as_float() + rhs.as_float());
+    }
+    case minus_int_int: {
+        COWEL_ASSERT(lhs.is_int() && rhs.is_int());
+        return Value::integer(lhs.as_integer() - rhs.as_integer());
+    }
+    case minus_float_float: {
+        COWEL_ASSERT(lhs.is_float() && rhs.is_float());
+        return Value::floating(lhs.as_float() - rhs.as_float());
+    }
+    case multiply_int_int: {
+        COWEL_ASSERT(lhs.is_int() && rhs.is_int());
+        return Value::integer(lhs.as_integer() * rhs.as_integer());
+    }
+    case multiply_float_float: {
+        COWEL_ASSERT(lhs.is_float() && rhs.is_float());
+        return Value::floating(lhs.as_float() * rhs.as_float());
+    }
+    case div_float_float: {
+        COWEL_ASSERT(lhs.is_float() && rhs.is_float());
         return Value::floating(lhs.as_float() / rhs.as_float());
     }
-
-    // Remainder: integer operands only.
-    if (kind == Binary_Expression_Kind::remainder) {
-        bool ok = true;
-        if (!lhs.is_int()) {
-            context.try_error(
-                diagnostic::type_mismatch, lhs_location,
-                joined_char_sequence(
-                    {
-                        u8"Expected a value of type "sv,
-                        Type::integer.get_display_name(),
-                        u8", but got "sv,
-                        lhs.get_type().get_display_name(),
-                        u8".",
-                    }
-                )
-            );
-            ok = false;
-        }
-        if (!rhs.is_int()) {
-            context.try_error(
-                diagnostic::type_mismatch, rhs_location,
-                joined_char_sequence(
-                    {
-                        u8"Expected a value of type "sv,
-                        Type::integer.get_display_name(),
-                        u8", but got "sv,
-                        rhs.get_type().get_display_name(),
-                        u8".",
-                    }
-                )
-            );
-            ok = false;
-        }
-        if (!ok) {
-            return Processing_Status::error;
-        }
+    case rem_to_zero_int_int: {
+        COWEL_ASSERT(lhs.is_int() && rhs.is_int());
         if (rhs.as_integer().is_zero()) {
             context.try_error(
                 diagnostic::arithmetic_div_by_zero, rhs_location, u8"Division by zero."sv
@@ -457,84 +659,8 @@ Result<Value, Processing_Status> evaluate_binary_numeric(
         }
         return Value::integer(lhs.as_integer() % rhs.as_integer());
     }
-
-    // Addition, subtraction, multiplication: integer or float, same type.
-    static constexpr Type numeric_types[] { Type::integer, Type::floating };
-    static constexpr auto numeric_type = Type::union_of(numeric_types);
-    static_assert(numeric_type.is_canonical());
-
-    bool ok = true;
-    if (!lhs.get_type().analytically_convertible_to(numeric_type)) {
-        context.try_error(
-            diagnostic::type_mismatch, lhs_location,
-            joined_char_sequence(
-                {
-                    u8"Expected a value of type "sv,
-                    numeric_type.get_display_name(),
-                    u8", but got "sv,
-                    lhs.get_type().get_display_name(),
-                    u8".",
-                }
-            )
-        );
-        ok = false;
     }
-    if (!rhs.get_type().analytically_convertible_to(numeric_type)) {
-        context.try_error(
-            diagnostic::type_mismatch, rhs_location,
-            joined_char_sequence(
-                {
-                    u8"Expected a value of type "sv,
-                    numeric_type.get_display_name(),
-                    u8", but got "sv,
-                    rhs.get_type().get_display_name(),
-                    u8".",
-                }
-            )
-        );
-        ok = false;
-    }
-    if (!ok) {
-        return Processing_Status::error;
-    }
-    if (lhs.get_type() != rhs.get_type()) {
-        context.try_error(
-            diagnostic::type_mismatch, rhs_location,
-            joined_char_sequence(
-                {
-                    u8"Both operands must be of the same type, but left-hand side is "sv,
-                    lhs.get_type().get_display_name(),
-                    u8" and right-hand side is "sv,
-                    rhs.get_type().get_display_name(),
-                    u8".",
-                }
-            )
-        );
-        return Processing_Status::error;
-    }
-
-    switch (kind) {
-    case Binary_Expression_Kind::plus: {
-        if (lhs.is_int()) {
-            return Value::integer(lhs.as_integer() + rhs.as_integer());
-        }
-        return Value::floating(lhs.as_float() + rhs.as_float());
-    }
-    case Binary_Expression_Kind::minus: {
-        if (lhs.is_int()) {
-            return Value::integer(lhs.as_integer() - rhs.as_integer());
-        }
-        return Value::floating(lhs.as_float() - rhs.as_float());
-    }
-    case Binary_Expression_Kind::multiply: {
-        if (lhs.is_int()) {
-            return Value::integer(lhs.as_integer() * rhs.as_integer());
-        }
-        return Value::floating(lhs.as_float() * rhs.as_float());
-    }
-    default: break;
-    }
-    COWEL_ASSERT_UNREACHABLE(u8"Unexpected binary numeric kind.");
+    COWEL_ASSERT_UNREACHABLE(u8"All switch cases should have returned.");
 }
 
 } // namespace cowel

--- a/engine/src/semantics.cpp
+++ b/engine/src/semantics.cpp
@@ -528,129 +528,98 @@ Result<Value, Processing_Status> evaluate_builtin(
         return Value::false_;
     }
     case logical_or_bool_bool: {
-        COWEL_ASSERT(lhs.is_bool() && rhs.is_bool());
         return Value::boolean(lhs.as_boolean() || rhs.as_boolean());
     }
     case logical_and_bool_bool: {
-        COWEL_ASSERT(lhs.is_bool() && rhs.is_bool());
         return Value::boolean(lhs.as_boolean() && rhs.as_boolean());
     }
     case eq_bool_bool: {
-        COWEL_ASSERT(lhs.is_bool() && rhs.is_bool());
         return Value::boolean(lhs.as_boolean() == rhs.as_boolean());
     }
     case eq_int_int: {
-        COWEL_ASSERT(lhs.is_int() && rhs.is_int());
         return Value::boolean(lhs.as_integer() == rhs.as_integer());
     }
     case eq_float_float: {
-        COWEL_ASSERT(lhs.is_float() && rhs.is_float());
         return Value::boolean(lhs.as_float() == rhs.as_float());
     }
     case eq_dynamic_groups: {
-        COWEL_ASSERT(lhs.is_group() && rhs.is_group());
         return Value::boolean(members_equal(
             lhs.get_group_members(), rhs.get_group_members(), lhs_location, rhs_location, context
         ));
     }
     case eq_str_str: {
-        COWEL_ASSERT(lhs.is_str() && rhs.is_str());
         return Value::boolean(lhs.as_string() == rhs.as_string());
     }
     case ne_bool_bool: {
-        COWEL_ASSERT(lhs.is_bool() && rhs.is_bool());
         return Value::boolean(lhs.as_boolean() != rhs.as_boolean());
     }
     case ne_int_int: {
-        COWEL_ASSERT(lhs.is_int() && rhs.is_int());
         return Value::boolean(lhs.as_integer() != rhs.as_integer());
     }
     case ne_float_float: {
-        COWEL_ASSERT(lhs.is_float() && rhs.is_float());
         return Value::boolean(lhs.as_float() != rhs.as_float());
     }
     case ne_str_str: {
-        COWEL_ASSERT(lhs.is_str() && rhs.is_str());
         return Value::boolean(lhs.as_string() != rhs.as_string());
     }
     case lt_int_int: {
-        COWEL_ASSERT(lhs.is_int() && rhs.is_int());
         return Value::boolean(lhs.as_integer() < rhs.as_integer());
     }
     case lt_float_float: {
-        COWEL_ASSERT(lhs.is_float() && rhs.is_float());
         return Value::boolean(lhs.as_float() < rhs.as_float());
     }
     case lt_str_str: {
-        COWEL_ASSERT(lhs.is_str() && rhs.is_str());
         return Value::boolean(lhs.as_string() < rhs.as_string());
     }
     case gt_int_int: {
-        COWEL_ASSERT(lhs.is_int() && rhs.is_int());
         return Value::boolean(lhs.as_integer() > rhs.as_integer());
     }
     case gt_float_float: {
-        COWEL_ASSERT(lhs.is_float() && rhs.is_float());
         return Value::boolean(lhs.as_float() > rhs.as_float());
     }
     case gt_str_str: {
-        COWEL_ASSERT(lhs.is_str() && rhs.is_str());
         return Value::boolean(lhs.as_string() > rhs.as_string());
     }
     case le_int_int: {
-        COWEL_ASSERT(lhs.is_int() && rhs.is_int());
         return Value::boolean(lhs.as_integer() <= rhs.as_integer());
     }
     case le_float_float: {
-        COWEL_ASSERT(lhs.is_float() && rhs.is_float());
         return Value::boolean(lhs.as_float() <= rhs.as_float());
     }
     case le_str_str: {
-        COWEL_ASSERT(lhs.is_str() && rhs.is_str());
         return Value::boolean(lhs.as_string() <= rhs.as_string());
     }
     case ge_int_int: {
-        COWEL_ASSERT(lhs.is_int() && rhs.is_int());
         return Value::boolean(lhs.as_integer() >= rhs.as_integer());
     }
     case ge_float_float: {
-        COWEL_ASSERT(lhs.is_float() && rhs.is_float());
         return Value::boolean(lhs.as_float() >= rhs.as_float());
     }
     case ge_str_str: {
-        COWEL_ASSERT(lhs.is_str() && rhs.is_str());
         return Value::boolean(lhs.as_string() >= rhs.as_string());
     }
     case plus_int_int: {
-        COWEL_ASSERT(lhs.is_int() && rhs.is_int());
         return Value::integer(lhs.as_integer() + rhs.as_integer());
     }
     case plus_float_float: {
-        COWEL_ASSERT(lhs.is_float() && rhs.is_float());
         return Value::floating(lhs.as_float() + rhs.as_float());
     }
     case minus_int_int: {
-        COWEL_ASSERT(lhs.is_int() && rhs.is_int());
         return Value::integer(lhs.as_integer() - rhs.as_integer());
     }
     case minus_float_float: {
-        COWEL_ASSERT(lhs.is_float() && rhs.is_float());
         return Value::floating(lhs.as_float() - rhs.as_float());
     }
     case multiply_int_int: {
-        COWEL_ASSERT(lhs.is_int() && rhs.is_int());
         return Value::integer(lhs.as_integer() * rhs.as_integer());
     }
     case multiply_float_float: {
-        COWEL_ASSERT(lhs.is_float() && rhs.is_float());
         return Value::floating(lhs.as_float() * rhs.as_float());
     }
     case div_float_float: {
-        COWEL_ASSERT(lhs.is_float() && rhs.is_float());
         return Value::floating(lhs.as_float() / rhs.as_float());
     }
     case rem_to_zero_int_int: {
-        COWEL_ASSERT(lhs.is_int() && rhs.is_int());
         if (rhs.as_integer().is_zero()) {
             context.try_error(
                 diagnostic::arithmetic_div_by_zero, rhs_location, u8"Division by zero."sv

--- a/engine/test/src/test_value.cpp
+++ b/engine/test/src/test_value.cpp
@@ -329,42 +329,42 @@ TEST(Type, analytically_convertible_to)
     static_assert(int_and_float.is_canonical());
     static constexpr auto lazy_int = Type::lazy(&Type::integer);
 
-    EXPECT_TRUE(Type::any.analytically_convertible_to(Type::any));
-    EXPECT_TRUE(Type::nothing.analytically_convertible_to(Type::nothing));
-    EXPECT_TRUE(Type::unit.analytically_convertible_to(Type::unit));
-    EXPECT_TRUE(Type::null.analytically_convertible_to(Type::null));
-    EXPECT_TRUE(Type::integer.analytically_convertible_to(Type::integer));
-    EXPECT_TRUE(Type::floating.analytically_convertible_to(Type::floating));
+    EXPECT_TRUE(Type::any.instance_of(Type::any));
+    EXPECT_TRUE(Type::nothing.instance_of(Type::nothing));
+    EXPECT_TRUE(Type::unit.instance_of(Type::unit));
+    EXPECT_TRUE(Type::null.instance_of(Type::null));
+    EXPECT_TRUE(Type::integer.instance_of(Type::integer));
+    EXPECT_TRUE(Type::floating.instance_of(Type::floating));
 
-    EXPECT_TRUE(int_or_float.analytically_convertible_to(Type::any));
-    EXPECT_FALSE(Type::any.analytically_convertible_to(int_or_float));
-    EXPECT_TRUE(Type::nothing.analytically_convertible_to(int_or_float));
-    EXPECT_TRUE(Type::integer.analytically_convertible_to(int_or_float));
-    EXPECT_TRUE(Type::floating.analytically_convertible_to(int_or_float));
-    EXPECT_FALSE(int_or_float.analytically_convertible_to(Type::integer));
-    EXPECT_FALSE(int_or_float.analytically_convertible_to(Type::floating));
+    EXPECT_TRUE(int_or_float.instance_of(Type::any));
+    EXPECT_FALSE(Type::any.instance_of(int_or_float));
+    EXPECT_TRUE(Type::nothing.instance_of(int_or_float));
+    EXPECT_TRUE(Type::integer.instance_of(int_or_float));
+    EXPECT_TRUE(Type::floating.instance_of(int_or_float));
+    EXPECT_FALSE(int_or_float.instance_of(Type::integer));
+    EXPECT_FALSE(int_or_float.instance_of(Type::floating));
 
-    EXPECT_TRUE(Type::integer.analytically_convertible_to(lazy_int));
-    EXPECT_FALSE(lazy_int.analytically_convertible_to(Type::integer));
+    EXPECT_TRUE(Type::integer.instance_of(lazy_int));
+    EXPECT_FALSE(lazy_int.instance_of(Type::integer));
 
-    EXPECT_TRUE(Type::group.analytically_convertible_to(Type::group));
+    EXPECT_TRUE(Type::group.instance_of(Type::group));
 
-    EXPECT_TRUE(Type::empty_group.analytically_convertible_to(Type::group));
-    EXPECT_TRUE(Type::empty_group.analytically_convertible_to(Type::empty_group));
-    EXPECT_FALSE(Type::empty_group.analytically_convertible_to(int_and_float));
+    EXPECT_TRUE(Type::empty_group.instance_of(Type::group));
+    EXPECT_TRUE(Type::empty_group.instance_of(Type::empty_group));
+    EXPECT_FALSE(Type::empty_group.instance_of(int_and_float));
 
-    EXPECT_TRUE(int_and_float.analytically_convertible_to(int_and_float));
-    EXPECT_TRUE(int_and_float.analytically_convertible_to(Type::group));
-    EXPECT_FALSE(int_and_float.analytically_convertible_to(Type::empty_group));
+    EXPECT_TRUE(int_and_float.instance_of(int_and_float));
+    EXPECT_TRUE(int_and_float.instance_of(Type::group));
+    EXPECT_FALSE(int_and_float.instance_of(Type::empty_group));
 
     static constexpr Type some_union_types[] { Type::integer, int_and_float };
     static constexpr auto some_union = Type::union_of(some_union_types);
     static_assert(some_union.is_canonical());
-    EXPECT_TRUE(int_and_float.analytically_convertible_to(some_union));
+    EXPECT_TRUE(int_and_float.instance_of(some_union));
 
-    EXPECT_FALSE(int_and_float.analytically_convertible_to(int_or_float));
-    EXPECT_FALSE(Type::integer.analytically_convertible_to(int_and_float));
-    EXPECT_FALSE(Type::floating.analytically_convertible_to(int_and_float));
+    EXPECT_FALSE(int_and_float.instance_of(int_or_float));
+    EXPECT_FALSE(Type::integer.instance_of(int_and_float));
+    EXPECT_FALSE(Type::floating.instance_of(int_and_float));
 }
 
 } // namespace

--- a/engine/test/src/test_value.cpp
+++ b/engine/test/src/test_value.cpp
@@ -320,7 +320,7 @@ TEST(Type, canonical_union_of)
     EXPECT_EQ(Type::canonical_union_of(types), Type::union_of(unit_and_integer_types));
 }
 
-TEST(Type, analytically_convertible_to)
+TEST(Type, instance_of)
 {
     static constexpr Type int_float_types[] { Type::integer, Type::floating };
     static constexpr auto int_or_float = Type::union_of(int_float_types);


### PR DESCRIPTION
This gets rid of some dead code and overall cleans up evaluation.

The idea is that evaluation is split up into type checking and the actual computation, via `check_operation` and `evaluate_builtin` functions.

In the long run, `evaluate_builtin` will turn into a mega-function that performs evaluation of any concrete builtin operation. This will be helpful for implementing evaluation of the VM instructions generated from functions and things like that.