### PR TITLE
Determine the `String_Kind` in AST creation

### DIFF
--- a/engine/src/directive_processing.cpp
+++ b/engine/src/directive_processing.cpp
@@ -919,13 +919,19 @@ evaluate(const ast::Primary& value, Frame_Index frame, Context& context)
         return *var;
     }
     case ast::Primary_Kind::quoted_string: {
+        // TODO: This is somewhat suboptimal because if there is only a single piece of text
+        //       or only a single escape sequence,
+        //       we don't need an extra dynamic buffer for splicing.
+        //       We also don't need to re-compute the string kind then.
         Vector_Text_Sink text { Output_Language::text, context.get_transient_memory() };
         Text_Only_Policy policy { text };
         const Processing_Status result = splice_primary(policy, value, frame, context);
         if (result != Processing_Status::ok) {
             return result;
         }
-        return Value::string(as_u8string_view(*text), value.get_string_kind());
+        const auto result_str = as_u8string_view(*text);
+        const auto kind = is_all_ascii(result_str) ? String_Kind::ascii : String_Kind::unicode;
+        return Value::string(result_str, kind);
     }
     case ast::Primary_Kind::block: {
         return Value::block(value, frame);

--- a/engine/src/syntax/build_ast.cpp
+++ b/engine/src/syntax/build_ast.cpp
@@ -34,8 +34,12 @@ Primary Primary::basic(Primary_Kind kind, File_Source_Span source_span, std::u8s
     switch (kind) {
     case unit_literal:
     case null_literal:
-    case bool_literal:
-    case text: return Primary { kind, source_span, source, std::monostate {} };
+    case bool_literal: return Primary { kind, source_span, source, std::monostate {} };
+
+    case text: {
+        const auto string_kind = is_all_ascii(source) ? String_Kind::ascii : String_Kind::unicode;
+        return Primary { kind, source_span, source, std::monostate {}, string_kind };
+    }
 
     case unquoted_member_name:
     case id_expression: {


### PR DESCRIPTION
The current behavior is to construct all text with `String_Kind::unknown`, which isn't incorrect, but not great for performance because it prevents the use of ASCII-specific algorithms.