### PR TITLE
Add `cowel_char_get_name` directive

### DIFF
--- a/.github/instructions/new-directive.instructions.md
+++ b/.github/instructions/new-directive.instructions.md
@@ -1,0 +1,205 @@
+---
+description: "Use when adding a new builtin directive to COWEL: implementing the behavior struct, registering in the directive table, writing semantic tests, adding documentation in new_directives.cow, updating CHANGELOG.md and lang-summary.md."
+---
+
+# Adding a New Builtin Directive
+
+Every new `cowel_*` builtin directive requires ALL of the following steps.
+Complete them in order; each step depends on the previous ones being in place.
+
+## 1. Declare the behavior struct
+
+**File:** `engine/include/cowel/builtin_directive_set.hpp`
+
+Insert the struct **alphabetically by directive name** relative to adjacent structs.
+
+Choose the right base class based on the return type:
+
+| Return type | Base class | Override method |
+|---|---|---|
+| `int` | `Int_Directive_Behavior` | `do_evaluate` → `Result<Big_Int, Processing_Status>` |
+| `str` (≤56 bytes) | `Short_String_Directive_Behavior` | `do_evaluate` → `Result<Short_String_Value, Processing_Status>` |
+| `str` (any length) | `String_Sink_Behavior` | `do_spliced` |
+| `bool` | `Bool_Directive_Behavior` | `do_evaluate` → `Result<bool, Processing_Status>` |
+| union (`T \| null`) | `Directive_Behavior` directly | `evaluate` → `Result<Value, Processing_Status>` |
+| block/content | `Block_Directive_Behavior` | `splice` |
+
+For union return types (e.g. `str | null`, `int | null`), use this exact pattern:
+
+```cpp
+struct [[nodiscard]]
+Foo_Behavior final : Directive_Behavior {
+private:
+    static constexpr Type alternatives[] { Type::null, Type::str };
+    static constexpr Type return_type = Type::union_of(alternatives);
+    static_assert(return_type.is_canonical());
+
+public:
+    [[nodiscard]]
+    constexpr explicit Foo_Behavior()
+        : Directive_Behavior { return_type }
+    {
+    }
+
+    [[nodiscard]]
+    Result<Value, Processing_Status> evaluate(const Invocation&, Context&) const override;
+};
+```
+
+## 2. Register the directive
+
+**File:** `engine/src/builtin_directive_set.cpp`
+
+Both additions must be in **alphabetical order by directive name**.
+
+Add the constexpr instance near the top of the file:
+```cpp
+constexpr Foo_Behavior cowel_foo //
+    {};
+```
+
+Add the table entry in the sorted entries block:
+```cpp
+COWEL_NAME_AND_BEHAVIOR_ENTRY(cowel_foo),
+```
+
+The variable name (`cowel_foo`) is the directive name users call with `\cowel_foo`.
+
+## 3. Implement the behavior
+
+**File:** `engine/src/directives/<category>.cpp`
+(Use the existing file matching the directive's category, e.g. `code_point.cpp`,
+`str.cpp`. Create a new file only if adding an entirely new category.)
+
+Parameter-matching boilerplate — see surrounding functions in the same file:
+```cpp
+Result<..., Processing_Status>
+Foo_Behavior::evaluate(const Invocation& call, Context& context) const
+{
+    String_Matcher x_matcher { context.get_transient_memory() };
+    Parameter x_parameter { u8"x", Optionality::mandatory, x_matcher };
+    Parameter* const parameters[] { &x_parameter };
+
+    const auto args_status = match_call(parameters, call, context);
+    if (args_status != Processing_Status::ok) {
+        return args_status;
+    }
+    // ...
+}
+```
+
+Common diagnostics:
+- `diagnostic::type_mismatch` —
+    automatically emitted by `match_call` when argument types are wrong.
+
+## 4. Write a semantic test
+
+**File:** `engine/test/files/semantics/<category>/<directive_stem>.cow`
+
+Test files are discovered automatically — no registration needed.
+Name the file after the directive name suffix
+(e.g. `cowel_char_get_name` → `char/get_name.cow`).
+
+Format:
+```cowel
+\test_input{
+\directive_name("happy path value")
+
+\test_expect_warning("warning.id"){\directive_name("warns on this")}
+
+\test_expect_error("type.mismatch"){\directive_name()}
+\test_expect_error("relevant.id"){\directive_name("")}
+}
+
+\test_output{
+expected output
+
+warned-case output
+
+<error->\directive_name()</error->
+<error->\directive_name("")</error->
+}
+```
+
+Rules:
+- **Nested directive calls inside argument `(...)` must omit `\`.**
+  Write `\foo(bar("x"))` not `\foo(\bar("x"))`.
+  The `\` prefix is only for directive calls in document-text context.
+- Always test: the normal happy-path case, `type.mismatch` for missing required
+  args, and any directive-specific error and warning cases.
+- If the directive can return `null`, test that case; spliced `null` renders as
+  the string `"null"` in the output.
+- Use `\:` comments to label each case.
+
+## 5. Add documentation
+
+**File:** `docs/new_directives.cow`
+
+Insert a `\cowdoc_dir_h4` section in the correct `\h3` group,
+maintaining alphabetical or logical order within the group:
+
+```cowel
+\cowdoc_dir_h4("cowel_foo", "Human-readable title")
+
+\pre{
+\cowel_highlight_as("markup-tag"){cowel_foo}(\cowdoc_param("x", "str")): \cowel_highlight_as("keyword-type"){str}
+}
+
+Prose description of what the directive does.
+
+\Bex{
+COWEL markup:
+\cowblock{\literally{
+\cowel_foo("example")
+}}
+Generated HTML:
+\htmlblock{
+\cowel_foo("example")
+}
+}
+```
+
+After editing, **regenerate the golden HTML**:
+```bash
+./build/cowel-cli run docs/index.cow docs/index.html
+```
+
+This updates `docs/index.html`,
+which is checked by `Document_Generation.documentation`.
+Forgetting this step causes that test to fail.
+
+## 6. Update `CHANGELOG.md`
+
+Under `### Engine` in the current unreleased version block:
+```markdown
+- Added `cowel_foo` directive for <brief description> (#NNN)
+```
+
+`#NNN` is the issue or pull request number for this change.
+Do not create issues yourself; request a number from the user.
+
+## 7. Update `.github/lang-summary.md`
+
+If the directive is broadly useful,
+add it to the "Essential builtin directives"
+code block with a brief inline comment:
+
+```cowel
+\cowel_foo("example")     \: what it does
+```
+
+Per project policy, `.github/copilot-instructions.md` and
+`.github/lang-summary.md` must both stay in sync whenever builtins change.
+Update both if the new directive is worth listing,
+but this is rarely the case.
+
+## 8. Build and verify
+
+```bash
+cmake --build build --config Debug -j4
+ctest --test-dir build --output-on-failure
+```
+
+All tests must pass, including:
+- `Document_Generation.file_tests` — the new semantic test
+- `Document_Generation.documentation` — the regenerated golden HTML

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   such as to generate `<h1 id=int><h- data-h=kw_type>int</h></h1>` automatically
   from a syntax-highlighted title (notice that `id=int` is plain text).
 - Added `cowel_str_substr` directive for taking substrings (#333)
+- Added `cowel_char_get_name` directive for obtaining code point names (#363)
 - Updated µlight for various syntax highlighting fixes (#336)
 - Fixed crash on file ending in closing parenthesis of a *group* (#352)
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1627,6 +1627,8 @@ h1 {
 <a href=#dir-cowel_char_by_num><h4><code><h- data-h=mk_tag>\cowel_char_by_num</h-></code> — Character by code point number</h4></a>
 <div class=toc-num data-level=4>9.2.4</div>
 <a href=#dir-cowel_char_get_num><h4><code><h- data-h=mk_tag>\cowel_char_get_num</h-></code> — Get digits of character</h4></a>
+<div class=toc-num data-level=4>9.2.5</div>
+<a href=#dir-cowel_char_get_name><h4><code><h- data-h=mk_tag>\cowel_char_get_name</h-></code> — Get name of character</h4></a>
 <div class=toc-num data-level=3>9.3</div>
 <a href=#html-utilities><h3>HTML utilities</h3></a>
 <div class=toc-num data-level=4>9.3.1</div>
@@ -4439,6 +4441,51 @@ some input is discarded:
 </div>
 <p>... which corresponds to '<tt->a</tt->',
 whereas '<tt->b</tt->' and '<tt->c</tt->' are discarded.
+</p></bug-block>
+
+<h4 id=dir-cowel_char_get_name><a class=para href=#dir-cowel_char_get_name></a>9.2.5. <code><h- data-h=mk_tag>\cowel_char_get_name</h-></code> — Get name of character</h4>
+
+<pre>
+<h- data-h=mk_tag>cowel_char_get_name</h->(<h- data-h=mk_attr>x</h->: <h- data-h=kw_type>str</h->): <h- data-h=kw_type>str | null</h->
+</pre>
+
+<p>The <code><h- data-h=mk_tag>\cowel_char_get_name</h-></code> directive returns the official Unicode name
+of the first code point in <tt-><h- data-h=mk_attr>x</h-></tt->.
+If the code point has no official Unicode name
+(e.g. control characters, private-use characters, surrogates, and reserved code points),
+<code>null</code> is returned instead.
+</p>
+<note-block><p><intro-></intro-> 
+Only the Unicode code point name is returned,
+not correction aliases or other aliases.
+For example,
+U+2118 ℘ has the official name <tt->SCRIPT CAPITAL P</tt->
+and the correction alias <tt->WEIERSTRASS ELLIPTIC FUNCTION</tt->;
+this directive returns the former.
+</p></note-block>
+
+<example-block><p><intro-></intro-> 
+COWEL markup:
+</p><code-block><h- data-h=mk_tag>\cowel_char_get_name</h-><h- data-h=sym_par>(</h-><h- data-h=str_dlim>"</h-><h- data-h=str>A</h-><h- data-h=str_dlim>"</h-><h- data-h=sym_par>)</h->
+<h- data-h=mk_tag>\cowel_char_get_name</h-><h- data-h=sym_par>(</h-><h- data-h=str_dlim>"</h-><h- data-h=str>¶</h-><h- data-h=str_dlim>"</h-><h- data-h=sym_par>)</h->
+<h- data-h=cmt_dlim>\:</h-><h- data-h=cmt> U+2118 has a correction alias but the official name is returned.</h->
+<h- data-h=mk_tag>\cowel_char_get_name</h-><h- data-h=sym_par>(</h-><h- data-h=str_dlim>"</h-><h- data-h=str>℘</h-><h- data-h=str_dlim>"</h-><h- data-h=sym_par>)</h-></code-block>
+<p>Generated HTML:
+</p><code-block>LATIN CAPITAL LETTER A
+PILCROW SIGN
+SCRIPT CAPITAL P</code-block>
+</example-block>
+
+<bug-block><p><intro-></intro-> 
+If more than one code point is provided,
+some input is discarded:
+</p><code-block><h- data-h=mk_tag>\</h-><h- data-h=mk_tag>cowel_char_get_name</h-><h- data-h=sym_par>(</h-><h- data-h=str_dlim>"</h-><h- data-h=str>AB</h-><h- data-h=str_dlim>"</h-><h- data-h=sym_par>)</h-></code-block>
+<p>This renders as
+</p><div class=indent>
+LATIN CAPITAL LETTER A
+</div>
+<p>... which corresponds to '<tt->A</tt->',
+whereas '<tt->B</tt->' is discarded.
 </p></bug-block>
 
 <h3 id=html-utilities><a class=para href=#html-utilities></a>9.3. HTML utilities</h3>

--- a/docs/new_directives.cow
+++ b/docs/new_directives.cow
@@ -295,6 +295,57 @@ This renders as
 whereas '\tt{b}' and '\tt{c}' are discarded.
 }
 
+\cowdoc_dir_h4("cowel_char_get_name", "Get name of character")
+
+\pre{
+\cowel_highlight_as("markup-tag"){cowel_char_get_name}(\cowdoc_param("x", "str")): \cowel_highlight_as("keyword-type"){str | null}
+}
+
+The \cowdoc_dir{cowel_char_get_name} directive returns the official Unicode name
+of the first code point in \cowdoc_attr{x}.
+If the code point has no official Unicode name
+(e.g. control characters, private-use characters, surrogates, and reserved code points),
+\cowdoc_c{null} is returned instead.
+
+\Bnote{
+Only the Unicode code point name is returned,
+not correction aliases or other aliases.
+For example,
+U+2118 ℘ has the official name \tt{SCRIPT CAPITAL P}
+and the correction alias \tt{WEIERSTRASS ELLIPTIC FUNCTION};
+this directive returns the former.
+}
+
+\Bex{
+COWEL markup:
+\cowblock{\literally{
+\cowel_char_get_name("A")
+\cowel_char_get_name("¶")
+\: U+2118 has a correction alias but the official name is returned.
+\cowel_char_get_name("℘")
+}}
+Generated HTML:
+\htmlblock{
+\cowel_char_get_name("A")
+\cowel_char_get_name("¶")
+\cowel_char_get_name("℘")
+}
+}
+
+\Bug{
+If more than one code point is provided,
+some input is discarded:
+\cowblock{
+\\cowel_char_get_name("AB")
+}
+This renders as
+\Bindent{
+\cowel_char_get_name("A")
+}
+... which corresponds to '\tt{A}',
+whereas '\tt{B}' is discarded.
+}
+
 \h3{HTML utilities}
 
 \cowdoc_dir_h4("cowel_html_element", "HTML element")

--- a/engine/include/cowel/builtin_directive_set.hpp
+++ b/engine/include/cowel/builtin_directive_set.hpp
@@ -145,6 +145,24 @@ Char_By_Name_Behavior final : Code_Point_Behavior {
 };
 
 struct [[nodiscard]]
+Char_Get_Name_Behavior final : Directive_Behavior {
+private:
+    static constexpr Type alternatives[] { Type::null, Type::str };
+    static constexpr Type return_type = Type::union_of(alternatives);
+    static_assert(return_type.is_canonical());
+
+public:
+    [[nodiscard]]
+    constexpr explicit Char_Get_Name_Behavior()
+        : Directive_Behavior { return_type }
+    {
+    }
+
+    [[nodiscard]]
+    Result<Value, Processing_Status> evaluate(const Invocation&, Context&) const override;
+};
+
+struct [[nodiscard]]
 Char_Get_Num_Behavior final : Int_Directive_Behavior {
     [[nodiscard]]
     constexpr explicit Char_Get_Num_Behavior()

--- a/engine/src/builtin_directive_set.cpp
+++ b/engine/src/builtin_directive_set.cpp
@@ -55,6 +55,8 @@ constexpr Char_By_Name_Behavior cowel_char_by_name //
     {};
 constexpr Char_By_Num_Behavior cowel_char_by_num //
     {};
+constexpr Char_Get_Name_Behavior cowel_char_get_name //
+    {};
 constexpr Char_Get_Num_Behavior cowel_char_get_num //
     {};
 constexpr N_Ary_Numeric_Expression_Behavior cowel_div //
@@ -533,6 +535,7 @@ constexpr Name_And_Behavior behaviors_by_name[] {
     COWEL_NAME_AND_BEHAVIOR_ENTRY(cowel_char_by_entity),
     COWEL_NAME_AND_BEHAVIOR_ENTRY(cowel_char_by_name),
     COWEL_NAME_AND_BEHAVIOR_ENTRY(cowel_char_by_num),
+    COWEL_NAME_AND_BEHAVIOR_ENTRY(cowel_char_get_name),
     COWEL_NAME_AND_BEHAVIOR_ENTRY(cowel_char_get_num),
     COWEL_NAME_AND_BEHAVIOR_ENTRY(cowel_div),
     COWEL_NAME_AND_BEHAVIOR_ENTRY(cowel_div_to_neg_inf),

--- a/engine/src/directives/code_point.cpp
+++ b/engine/src/directives/code_point.cpp
@@ -154,4 +154,55 @@ Char_Get_Num_Behavior::do_evaluate(const Invocation& call, Context& context) con
     return Big_Int { Int128 { code_point } };
 }
 
+Result<Value, Processing_Status>
+Char_Get_Name_Behavior::evaluate(const Invocation& call, Context& context) const
+{
+    String_Matcher x_matcher { context.get_transient_memory() };
+    Parameter x_parameter { u8"x", Optionality::mandatory, x_matcher };
+    Parameter* const parameters[] { &x_parameter };
+
+    const auto args_status = match_call(parameters, call, context);
+    if (args_status != Processing_Status::ok) {
+        return args_status;
+    }
+
+    const std::u8string_view input_text = x_matcher.get();
+
+    if (input_text.empty()) {
+        context.try_error(
+            diagnostic::char_blank, call.directive.get_source_span(),
+            u8"Nothing can be generated because the input is empty."sv
+        );
+        return Processing_Status::error;
+    }
+
+    const std::expected<utf8::Code_Point_And_Length, utf8::Unicode_Error> decode_result
+        = utf8::decode_and_length(input_text);
+    if (!decode_result) {
+        context.try_error(
+            diagnostic::char_corrupted, call.directive.get_source_span(),
+            u8"The input could not be interpreted as a code point because it is malformed UTF-8."sv
+        );
+        return Processing_Status::error;
+    }
+
+    const auto [code_point, length] = *decode_result;
+    if (std::size_t(length) != input_text.size()) {
+        COWEL_ASSERT(std::size_t(length) <= input_text.size());
+        context.try_warning(
+            diagnostic::ignored_input, call.directive.get_source_span(),
+            u8"Some of the code units inside were ignored because only the first given code point "
+            u8"is named. "
+            u8"This can happen if you type a glyph that consist of multiple "
+            u8"code points, like a country flag."sv
+        );
+    }
+
+    const Fixed_String8<96> name = code_point_name(code_point);
+    if (name.empty()) {
+        return Value::null;
+    }
+    return Value::string(name, String_Kind::ascii);
+}
+
 } // namespace cowel

--- a/engine/test/files/semantics/char/get_name.cow
+++ b/engine/test/files/semantics/char/get_name.cow
@@ -1,0 +1,27 @@
+\test_input{
+\: ASCII named code point
+\cowel_char_get_name("A")
+\: Multi-byte named code point
+\cowel_char_get_name("¶")
+\: Code point with correction alias - returns official name, not alias
+\cowel_char_get_name("℘")
+\: Control character - no official Unicode name, returns null
+\cowel_char_get_name(cowel_char_by_num(1))
+
+\test_expect_warning("ignored.input"){\cowel_char_get_name("AB")}
+
+\test_expect_error("type.mismatch"){\cowel_char_get_name()}
+\test_expect_error("char.blank"){\cowel_char_get_name("")}
+}
+
+\test_output{
+LATIN CAPITAL LETTER A
+PILCROW SIGN
+SCRIPT CAPITAL P
+null
+
+LATIN CAPITAL LETTER A
+
+<error->\cowel_char_get_name()</error->
+<error->\cowel_char_get_name("")</error->
+}


### PR DESCRIPTION
Closes #363

As a drive-by, this also adds an instructions file for adding new directives.