### PR TITLE
Make `Small_Vector` non-`constexpr`, don't require default construct

### DIFF
--- a/bindings/native/src/cli.cpp
+++ b/bindings/native/src/cli.cpp
@@ -3,6 +3,7 @@
 #include <filesystem>
 #include <iostream>
 #include <memory_resource>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -118,7 +119,7 @@ struct Stderr_Logger {
         const bool has_primary = stack_size != 0;
 
         File_Entry primary_file_entry {};
-        File_Source_Span primary_location {};
+        std::optional<File_Source_Span> primary_location;
         if (has_primary) {
             primary_file_entry = get_file_entry(stack[0]);
             primary_location = as_file_source_span(stack[0]);
@@ -137,7 +138,7 @@ struct Stderr_Logger {
                 print_location_of_file(out, primary_file_entry.name);
             }
             else {
-                print_file_position(out, primary_file_entry.name, primary_location);
+                print_file_position(out, primary_file_entry.name, *primary_location);
             }
         }
         out.append(u8' ');
@@ -153,7 +154,7 @@ struct Stderr_Logger {
         }
         out.append(u8'\n');
         if (has_primary && stack[0].length != 0) {
-            print_affected_line(out, primary_file_entry.source, primary_location);
+            print_affected_line(out, primary_file_entry.source, *primary_location);
         }
 
         for (std::size_t i = 1; i < stack_size; ++i) {

--- a/engine/include/cowel/parameters.hpp
+++ b/engine/include/cowel/parameters.hpp
@@ -169,10 +169,6 @@ private:
 
 public:
     [[nodiscard]]
-    Argument()
-        = default;
-
-    [[nodiscard]]
     const Value& get_name() const
     {
         return m_name;

--- a/engine/include/cowel/util/small_vector.hpp
+++ b/engine/include/cowel/util/small_vector.hpp
@@ -46,7 +46,10 @@ private:
     Alloc m_alloc {};
     T* m_dynamic_data = nullptr;
     union Small_Storage {
-        constexpr Small_Storage() noexcept { }
+        constexpr Small_Storage() noexcept
+            : dummy {}
+        {
+        }
         constexpr Small_Storage(const Small_Storage&) { }
         // NOLINTNEXTLINE(bugprone-unhandled-self-assignment)
         constexpr Small_Storage& operator=(const Small_Storage&)
@@ -54,8 +57,9 @@ private:
             return *this;
         }
         constexpr ~Small_Storage() noexcept { }
+        char dummy;
         T data[small_cap];
-    } m_small_storage;
+    } m_small_storage {};
 
 public:
     [[nodiscard]]

--- a/engine/include/cowel/util/small_vector.hpp
+++ b/engine/include/cowel/util/small_vector.hpp
@@ -28,11 +28,6 @@ public:
 
     static_assert(small_cap != 0, "Cannot create a Small_Vector with zero small capacity.");
     static_assert(
-        std::is_default_constructible_v<T>,
-        "Element types must be default-constructible. "
-        "This is necessary for a constexpr implementation."
-    );
-    static_assert(
         std::is_same_v<pointer, T*>,
         "Allocators with custom pointer types are not yet supported."
     );
@@ -50,7 +45,17 @@ private:
     [[no_unique_address]]
     Alloc m_alloc {};
     T* m_dynamic_data = nullptr;
-    T m_small_data[small_cap] {};
+    union Small_Storage {
+        constexpr Small_Storage() noexcept { }
+        constexpr Small_Storage(const Small_Storage&) { }
+        // NOLINTNEXTLINE(bugprone-unhandled-self-assignment)
+        constexpr Small_Storage& operator=(const Small_Storage&)
+        {
+            return *this;
+        }
+        constexpr ~Small_Storage() noexcept { }
+        T data[small_cap];
+    } m_small_storage;
 
 public:
     [[nodiscard]]
@@ -164,42 +169,42 @@ public:
     }
 
     [[nodiscard]]
-    constexpr T& operator[](const std::size_t i)
+    T& operator[](const std::size_t i)
     {
         COWEL_DEBUG_ASSERT(i < m_size);
-        return m_using_small ? m_small_data[i] : m_dynamic_data[i];
+        return m_using_small ? small_data()[i] : m_dynamic_data[i];
     }
 
     [[nodiscard]]
-    constexpr const T& operator[](const std::size_t i) const
+    const T& operator[](const std::size_t i) const
     {
         COWEL_DEBUG_ASSERT(i < m_size);
-        return m_using_small ? m_small_data[i] : m_dynamic_data[i];
+        return m_using_small ? small_data()[i] : m_dynamic_data[i];
     }
 
     [[nodiscard]]
-    constexpr T& front()
+    T& front()
     {
         COWEL_ASSERT(!empty());
         return operator[](0);
     }
 
     [[nodiscard]]
-    constexpr const T& front() const
+    const T& front() const
     {
         COWEL_ASSERT(!empty());
         return operator[](0);
     }
 
     [[nodiscard]]
-    constexpr T& back()
+    T& back()
     {
         COWEL_ASSERT(!empty());
         return operator[](m_size - 1);
     }
 
     [[nodiscard]]
-    constexpr const T& back() const
+    const T& back() const
     {
         COWEL_ASSERT(!empty());
         return operator[](m_size - 1);
@@ -221,7 +226,10 @@ public:
 
     constexpr void clear() noexcept
     {
-        if (!m_using_small) {
+        if (m_using_small) {
+            std::ranges::destroy_n(small_data(), difference_type(m_size));
+        }
+        else {
             std::ranges::destroy_n(m_dynamic_data, difference_type(m_size));
         }
         m_size = 0;
@@ -238,12 +246,13 @@ public:
 
     constexpr void resize(const std::size_t amount, const T& value = {})
     {
+        if (amount == 0) {
+            clear();
+            return;
+        }
         if (amount < m_size) {
-            if (amount == 0) {
-                clear();
-            }
-            else if (m_using_small) {
-                std::ranges::fill(m_small_data + amount, m_small_data + m_size, T {});
+            if (m_using_small) {
+                std::ranges::destroy(small_data() + amount, small_data() + m_size);
             }
             else {
                 std::ranges::destroy(m_dynamic_data + amount, m_dynamic_data + m_size);
@@ -251,7 +260,9 @@ public:
         }
         else if (amount > m_size) {
             if (m_using_small && amount <= small_cap) {
-                std::ranges::fill(m_small_data + m_size, m_small_data + amount, value);
+                std::ranges::uninitialized_fill(
+                    small_data() + m_size, small_data() + amount, value
+                );
             }
             else {
                 ensure_dynamic_storage(amount);
@@ -280,25 +291,21 @@ public:
 
         if (m_using_small && other.m_using_small) {
             const auto common = std::min(m_size, other.m_size);
-            std::ranges::swap_ranges(
-                m_small_data, //
-                m_small_data + common, //
-                other.m_small_data, //
-                other.m_small_data + common
-            );
+            T* const sd = small_data();
+            T* const osd = other.small_data();
+            std::ranges::swap_ranges(sd, sd + common, osd, osd + common);
             if (m_size > other.m_size) {
-                std::ranges::move(
-                    m_small_data + common, //
-                    m_small_data + m_size, //
-                    other.m_small_data + common
+                std::ranges::uninitialized_move_n(
+                    sd + common, difference_type(m_size - common), osd + common, osd + m_size
                 );
+                std::ranges::destroy_n(sd + common, difference_type(m_size - common));
             }
             else if (other.m_size > m_size) {
-                std::ranges::move(
-                    other.m_small_data + common, //
-                    other.m_small_data + other.m_size, //
-                    m_small_data + common
+                std::ranges::uninitialized_move_n(
+                    osd + common, difference_type(other.m_size - common), sd + common,
+                    sd + other.m_size
                 );
+                std::ranges::destroy_n(osd + common, difference_type(other.m_size - common));
             }
             std::swap(m_size, other.m_size);
             std::swap(m_dynamic_data, other.m_dynamic_data);
@@ -308,7 +315,11 @@ public:
         }
 
         if (!m_using_small && other.m_using_small) {
-            std::ranges::move(other.m_small_data, other.m_small_data + other.m_size, m_small_data);
+            std::ranges::uninitialized_move_n(
+                other.small_data(), difference_type(other.m_size), small_data(),
+                small_data() + other.m_size
+            );
+            std::ranges::destroy_n(other.small_data(), difference_type(other.m_size));
             std::swap(m_dynamic_data, other.m_dynamic_data);
             std::swap(m_dynamic_capacity, other.m_dynamic_capacity);
             std::swap(m_size, other.m_size);
@@ -318,7 +329,11 @@ public:
         }
 
         if (m_using_small && !other.m_using_small) {
-            std::ranges::move(m_small_data, m_small_data + m_size, other.m_small_data);
+            std::ranges::uninitialized_move_n(
+                small_data(), difference_type(m_size), other.small_data(),
+                other.small_data() + m_size
+            );
+            std::ranges::destroy_n(small_data(), difference_type(m_size));
             std::swap(m_dynamic_data, other.m_dynamic_data);
             std::swap(m_dynamic_capacity, other.m_dynamic_capacity);
             std::swap(m_size, other.m_size);
@@ -335,23 +350,24 @@ public:
         x.swap(y);
     }
 
-    constexpr void push_back(const T& element)
+    void push_back(const T& element)
     {
         emplace_back(element);
     }
 
-    constexpr void push_back(T&& element)
+    void push_back(T&& element)
     {
         emplace_back(std::move(element));
     }
 
     template <typename... Args>
         requires std::constructible_from<T, Args&&...>
-    constexpr T& emplace_back(Args&&... args)
+    T& emplace_back(Args&&... args)
     {
         if (m_using_small && m_size < small_cap) {
-            m_small_data[m_size] = T(std::forward<Args>(args)...);
-            return m_small_data[m_size++];
+            T* const p = std::construct_at(small_data() + m_size, std::forward<Args>(args)...);
+            ++m_size;
+            return *p;
         }
         ensure_dynamic_storage(m_size + 1);
         return *std::construct_at(
@@ -360,10 +376,13 @@ public:
         );
     }
 
-    constexpr void pop_back()
+    void pop_back()
     {
         COWEL_ASSERT(!empty());
-        if (!m_using_small) {
+        if (m_using_small) {
+            std::destroy_at(small_data() + m_size - 1);
+        }
+        else {
             std::destroy_at(m_dynamic_data + m_size - 1);
         }
         --m_size;
@@ -378,7 +397,7 @@ public:
     /// @param begin The start of the inserted range.
     /// @param sentinel A sentinel delimiting the inserted range.
     template <std::input_iterator Iterator, std::sentinel_for<Iterator> Sentinel>
-    constexpr void insert(iterator pos, Iterator begin, Sentinel sentinel)
+    void insert(iterator pos, Iterator begin, Sentinel sentinel)
     {
         const auto pos_index = std::size_t(pos - this->begin());
 
@@ -389,16 +408,33 @@ public:
             const std::size_t new_size = m_size + count;
 
             if (m_using_small && new_size <= small_cap) {
-                std::ranges::move_backward(
-                    m_small_data + pos_index, //
-                    m_small_data + m_size, //
-                    m_small_data + new_size
-                );
-                std::ranges::copy_n(
-                    begin, //
-                    std::iter_difference_t<Iterator>(count), //
-                    m_small_data + pos_index
-                );
+                T* const sd = small_data();
+                const std::size_t shift_count = m_size - pos_index;
+                if (count <= shift_count) {
+                    std::ranges::uninitialized_move_n(
+                        sd + (m_size - count), difference_type(count), sd + m_size,
+                        sd + m_size + count
+                    );
+                    std::ranges::move_backward(sd + pos_index, sd + (m_size - count), sd + m_size);
+                    std::ranges::copy_n(
+                        begin, std::iter_difference_t<Iterator>(count), sd + pos_index
+                    );
+                }
+                else {
+                    std::ranges::uninitialized_move_n(
+                        sd + pos_index, difference_type(shift_count), sd + pos_index + count,
+                        sd + pos_index + count + shift_count
+                    );
+                    const auto existing_result = std::ranges::copy_n(
+                        begin, std::iter_difference_t<Iterator>(shift_count), sd + pos_index
+                    );
+                    const std::size_t insert_tail_count = count - shift_count;
+                    std::ranges::uninitialized_copy_n(
+                        existing_result.in, std::iter_difference_t<Iterator>(insert_tail_count),
+                        sd + pos_index + shift_count,
+                        sd + pos_index + shift_count + insert_tail_count
+                    );
+                }
                 m_size = new_size;
                 return;
             }
@@ -458,7 +494,7 @@ public:
     }
 
     template <std::ranges::range R>
-    constexpr void append_range(R&& r)
+    void append_range(R&& r)
     {
         insert(
             end(), //
@@ -470,14 +506,12 @@ public:
     [[nodiscard]]
     constexpr iterator begin() noexcept
     {
-        return m_using_small ? std::ranges::begin(m_small_data) //
-                             : m_dynamic_data;
+        return m_using_small ? small_data() : m_dynamic_data;
     }
     [[nodiscard]]
     constexpr const_iterator begin() const noexcept
     {
-        return m_using_small ? std::ranges::begin(m_small_data) //
-                             : m_dynamic_data;
+        return m_using_small ? small_data() : m_dynamic_data;
     }
     [[nodiscard]]
     constexpr const_iterator cbegin() const noexcept
@@ -488,14 +522,12 @@ public:
     [[nodiscard]]
     constexpr iterator end() noexcept
     {
-        return m_using_small ? std::ranges::begin(m_small_data) + m_size //
-                             : m_dynamic_data + m_size;
+        return m_using_small ? small_data() + m_size : m_dynamic_data + m_size;
     }
     [[nodiscard]]
     constexpr const_iterator end() const noexcept
     {
-        return m_using_small ? std::ranges::begin(m_small_data) + m_size //
-                             : m_dynamic_data + m_size;
+        return m_using_small ? small_data() + m_size : m_dynamic_data + m_size;
     }
     [[nodiscard]]
     constexpr const_iterator cend() const noexcept
@@ -504,6 +536,18 @@ public:
     }
 
 private:
+    [[nodiscard]]
+    constexpr T* small_data() noexcept
+    {
+        return m_small_storage.data;
+    }
+
+    [[nodiscard]]
+    constexpr const T* small_data() const noexcept
+    {
+        return m_small_storage.data;
+    }
+
     constexpr void destroy_and_deallocate() noexcept
     {
         clear();
@@ -528,7 +572,10 @@ private:
         }
 
         m_size = std::exchange(other.m_size, 0);
-        std::ranges::move(other.m_small_data, other.m_small_data + m_size, m_small_data);
+        std::ranges::uninitialized_move_n(
+            other.small_data(), difference_type(m_size), small_data(), small_data() + m_size
+        );
+        std::ranges::destroy_n(other.small_data(), difference_type(m_size));
         m_using_small = true;
         if (other.m_dynamic_data) {
             m_dynamic_data = std::exchange(other.m_dynamic_data, nullptr);
@@ -548,22 +595,25 @@ private:
         );
     }
 
-    constexpr void move_dynamic_to_small()
+    void move_dynamic_to_small()
     {
-        std::ranges::move(m_dynamic_data, m_dynamic_data + m_size, m_small_data);
+        std::ranges::uninitialized_move_n(
+            m_dynamic_data, difference_type(m_size), small_data(), small_data() + m_size
+        );
         std::ranges::destroy_n(m_dynamic_data, difference_type(m_size));
         m_using_small = true;
     }
 
-    constexpr void move_small_to_dynamic(T* const target)
+    void move_small_to_dynamic(T* const target)
     {
         std::ranges::uninitialized_move_n(
-            m_small_data, difference_type(m_size), target, target + m_size
+            small_data(), difference_type(m_size), target, target + m_size
         );
+        std::ranges::destroy_n(small_data(), difference_type(m_size));
         m_using_small = false;
     }
 
-    constexpr void ensure_dynamic_storage(const std::size_t min_needed)
+    void ensure_dynamic_storage(const std::size_t min_needed)
     {
         if (!m_dynamic_data || m_dynamic_capacity < min_needed) {
             grow_to(min_needed);
@@ -587,8 +637,9 @@ private:
         }
         else {
             std::ranges::uninitialized_move_n(
-                m_small_data, difference_type(m_size), new_data, new_data + m_size
+                small_data(), difference_type(m_size), new_data, new_data + m_size
             );
+            std::ranges::destroy_n(small_data(), difference_type(m_size));
         }
 
         if (m_dynamic_data) {

--- a/engine/include/cowel/util/source_position.hpp
+++ b/engine/include/cowel/util/source_position.hpp
@@ -136,14 +136,6 @@ struct Basic_File_Source_Span : Source_Span {
     File file;
 
     [[nodiscard]]
-    constexpr Basic_File_Source_Span()
-        requires std::is_default_constructible_v<File>
-        : Source_Span {}
-        , file {}
-    {
-    }
-
-    [[nodiscard]]
     constexpr Basic_File_Source_Span(const Source_Span& local, File file)
         : Source_Span { local }
         , file { file }

--- a/engine/test/src/test_small_vector.cpp
+++ b/engine/test/src/test_small_vector.cpp
@@ -56,7 +56,7 @@ TEST(Small_Vector, default_constructor)
         EXPECT_EQ(vec.capacity(), 4);
         EXPECT_EQ(vec.small_capacity(), 4);
         EXPECT_TRUE(vec.small());
-        EXPECT_EQ(object_count, 4);
+        EXPECT_EQ(object_count, 0);
     }
     EXPECT_EQ(object_count, 0);
 }
@@ -69,12 +69,12 @@ TEST(Small_Vector, copy_constructor_small)
         vec1.push_back(Counted { 1 });
         vec1.push_back(Counted { 2 });
         EXPECT_TRUE(vec1.small());
-        EXPECT_EQ(object_count, 4);
+        EXPECT_EQ(object_count, 2);
 
         Small_Vector<Counted, 4> vec2 = vec1;
         EXPECT_EQ(vec2.size(), 2);
         EXPECT_TRUE(vec2.small());
-        EXPECT_EQ(object_count, 8);
+        EXPECT_EQ(object_count, 4);
         EXPECT_EQ(vec2[0].value, 1);
         EXPECT_EQ(vec2[1].value, 2);
     }
@@ -91,12 +91,12 @@ TEST(Small_Vector, copy_constructor_dynamic)
         vec1.push_back(Counted { 3 });
         vec1.push_back(Counted { 4 });
         EXPECT_FALSE(vec1.small());
-        EXPECT_EQ(object_count, 6);
+        EXPECT_EQ(object_count, 4);
 
         Small_Vector<Counted, 2> vec2 = vec1;
         EXPECT_EQ(vec2.size(), 4);
         EXPECT_FALSE(vec2.small());
-        EXPECT_EQ(object_count, 12);
+        EXPECT_EQ(object_count, 8);
         EXPECT_EQ(vec2[0].value, 1);
         EXPECT_EQ(vec2[1].value, 2);
         EXPECT_EQ(vec2[2].value, 3);
@@ -113,13 +113,13 @@ TEST(Small_Vector, move_constructor_small)
         vec1.push_back(Counted { 1 });
         vec1.push_back(Counted { 2 });
         EXPECT_TRUE(vec1.small());
-        EXPECT_EQ(object_count, 4);
+        EXPECT_EQ(object_count, 2);
 
         Small_Vector<Counted, 4> vec2 = std::move(vec1);
         EXPECT_EQ(vec2.size(), 2);
         EXPECT_TRUE(vec2.small());
         EXPECT_EQ(vec1.size(), 0);
-        EXPECT_EQ(object_count, 8);
+        EXPECT_EQ(object_count, 2);
         EXPECT_EQ(vec2[0].value, 1);
         EXPECT_EQ(vec2[1].value, 2);
     }
@@ -136,13 +136,13 @@ TEST(Small_Vector, move_constructor_dynamic)
         vec1.push_back(Counted { 3 });
         vec1.push_back(Counted { 4 });
         EXPECT_FALSE(vec1.small());
-        EXPECT_EQ(object_count, 6);
+        EXPECT_EQ(object_count, 4);
 
         Small_Vector<Counted, 2> vec2 = std::move(vec1);
         EXPECT_EQ(vec2.size(), 4);
         EXPECT_FALSE(vec2.small());
         EXPECT_EQ(vec1.size(), 0);
-        EXPECT_EQ(object_count, 8);
+        EXPECT_EQ(object_count, 4);
         EXPECT_EQ(vec2[0].value, 1);
         EXPECT_EQ(vec2[1].value, 2);
         EXPECT_EQ(vec2[2].value, 3);
@@ -168,7 +168,7 @@ TEST(Small_Vector, move_constructor_small_with_dynamic_allocation)
         EXPECT_EQ(vec2.size(), 2);
         EXPECT_TRUE(vec2.small());
         EXPECT_EQ(vec2.capacity(), 4);
-        EXPECT_EQ(object_count, 4);
+        EXPECT_EQ(object_count, 2);
         EXPECT_EQ(vec2[0].value, 1);
         EXPECT_EQ(vec2[1].value, 2);
     }
@@ -191,7 +191,7 @@ TEST(Small_Vector, copy_assignment)
         vec2 = vec1;
         EXPECT_EQ(vec2.size(), 2);
         EXPECT_TRUE(vec2.small());
-        EXPECT_EQ(object_count, 8);
+        EXPECT_EQ(object_count, 4);
         EXPECT_EQ(vec2[0].value, 1);
         EXPECT_EQ(vec2[1].value, 2);
     }
@@ -212,7 +212,7 @@ TEST(Small_Vector, copy_assignment_self)
         vec = *vec_pointer;
         EXPECT_EQ(vec.size(), 2);
         EXPECT_TRUE(vec.small());
-        EXPECT_EQ(object_count, 4);
+        EXPECT_EQ(object_count, 2);
         EXPECT_EQ(vec[0].value, 1);
         EXPECT_EQ(vec[1].value, 2);
     }
@@ -236,7 +236,7 @@ TEST(Small_Vector, move_assignment)
         EXPECT_EQ(vec2.size(), 2);
         EXPECT_EQ(vec1.size(), 0);
         EXPECT_TRUE(vec2.small());
-        EXPECT_EQ(object_count, 8);
+        EXPECT_EQ(object_count, 2);
         EXPECT_EQ(vec2[0].value, 1);
         EXPECT_EQ(vec2[1].value, 2);
     }
@@ -257,7 +257,7 @@ TEST(Small_Vector, move_assignment_self)
         vec = std::move(*vec_pointer);
         EXPECT_EQ(vec.size(), 2);
         EXPECT_TRUE(vec.small());
-        EXPECT_EQ(object_count, 4);
+        EXPECT_EQ(object_count, 2);
         EXPECT_EQ(vec[0].value, 1);
         EXPECT_EQ(vec[1].value, 2);
     }
@@ -273,7 +273,7 @@ TEST(Small_Vector, initializer_list_constructor)
         EXPECT_FALSE(vec.empty());
         EXPECT_TRUE(vec.small());
         EXPECT_EQ(vec.capacity(), 4);
-        EXPECT_EQ(object_count, 4);
+        EXPECT_EQ(object_count, 3);
         EXPECT_EQ(vec[0].value, 1);
         EXPECT_EQ(vec[1].value, 2);
         EXPECT_EQ(vec[2].value, 3);
@@ -290,14 +290,14 @@ TEST(Small_Vector, push_back_small)
         EXPECT_EQ(vec.size(), 1);
         EXPECT_FALSE(vec.empty());
         EXPECT_TRUE(vec.small());
-        EXPECT_EQ(object_count, 4);
+        EXPECT_EQ(object_count, 1);
         EXPECT_EQ(vec[0].value, 1);
 
         vec.push_back(Counted { 2 });
         vec.push_back(Counted { 3 });
         EXPECT_EQ(vec.size(), 3);
         EXPECT_TRUE(vec.small());
-        EXPECT_EQ(object_count, 4);
+        EXPECT_EQ(object_count, 3);
         EXPECT_EQ(vec[1].value, 2);
         EXPECT_EQ(vec[2].value, 3);
     }
@@ -321,7 +321,7 @@ TEST(Small_Vector, push_back_grow_to_dynamic)
         EXPECT_FALSE(vec.small());
         EXPECT_EQ(vec.size(), 3);
         EXPECT_GE(vec.capacity(), 4);
-        EXPECT_EQ(object_count, 5);
+        EXPECT_EQ(object_count, 3);
         EXPECT_EQ(vec[2].value, 3);
     }
     EXPECT_EQ(object_count, 0);
@@ -343,7 +343,7 @@ TEST(Small_Vector, emplace_back)
         vec.emplace_back(3);
         EXPECT_EQ(vec.size(), 3);
         EXPECT_FALSE(vec.small());
-        EXPECT_EQ(object_count, 5);
+        EXPECT_EQ(object_count, 3);
         EXPECT_EQ(vec[2].value, 3);
     }
     EXPECT_EQ(object_count, 0);
@@ -357,12 +357,12 @@ TEST(Small_Vector, pop_back_small)
         vec.push_back(Counted { 1 });
         vec.push_back(Counted { 2 });
         vec.push_back(Counted { 3 });
-        EXPECT_EQ(object_count, 4);
+        EXPECT_EQ(object_count, 3);
 
         vec.pop_back();
         EXPECT_EQ(vec.size(), 2);
         EXPECT_TRUE(vec.small());
-        EXPECT_EQ(object_count, 4);
+        EXPECT_EQ(object_count, 2);
         EXPECT_EQ(vec[0].value, 1);
         EXPECT_EQ(vec[1].value, 2);
     }
@@ -379,12 +379,12 @@ TEST(Small_Vector, pop_back_dynamic)
         vec.push_back(Counted { 3 });
         vec.push_back(Counted { 4 });
         EXPECT_FALSE(vec.small());
-        EXPECT_EQ(object_count, 6);
+        EXPECT_EQ(object_count, 4);
 
         vec.pop_back();
         EXPECT_EQ(vec.size(), 3);
         EXPECT_FALSE(vec.small());
-        EXPECT_EQ(object_count, 5);
+        EXPECT_EQ(object_count, 3);
         EXPECT_EQ(vec[0].value, 1);
         EXPECT_EQ(vec[1].value, 2);
         EXPECT_EQ(vec[2].value, 3);
@@ -401,7 +401,7 @@ TEST(Small_Vector, pop_back_transition_to_small)
         vec.push_back(Counted { 2 });
         vec.push_back(Counted { 3 });
         EXPECT_FALSE(vec.small());
-        EXPECT_EQ(object_count, 5);
+        EXPECT_EQ(object_count, 3);
 
         vec.pop_back();
         EXPECT_EQ(vec.size(), 2);
@@ -519,13 +519,13 @@ TEST(Small_Vector, clear_small)
         Small_Vector<Counted, 4> vec;
         vec.push_back(Counted { 1 });
         vec.push_back(Counted { 2 });
-        EXPECT_EQ(object_count, 4);
+        EXPECT_EQ(object_count, 2);
 
         vec.clear();
         EXPECT_EQ(vec.size(), 0);
         EXPECT_TRUE(vec.empty());
         EXPECT_TRUE(vec.small());
-        EXPECT_EQ(object_count, 4);
+        EXPECT_EQ(object_count, 0);
     }
     EXPECT_EQ(object_count, 0);
 }
@@ -540,13 +540,13 @@ TEST(Small_Vector, clear_dynamic)
         vec.push_back(Counted { 3 });
         vec.push_back(Counted { 4 });
         EXPECT_FALSE(vec.small());
-        EXPECT_EQ(object_count, 6);
+        EXPECT_EQ(object_count, 4);
 
         vec.clear();
         EXPECT_EQ(vec.size(), 0);
         EXPECT_TRUE(vec.empty());
         EXPECT_TRUE(vec.small());
-        EXPECT_EQ(object_count, 2);
+        EXPECT_EQ(object_count, 0);
     }
     EXPECT_EQ(object_count, 0);
 }
@@ -558,13 +558,13 @@ TEST(Small_Vector, reserve)
         Small_Vector<Counted, 2> vec;
         vec.push_back(Counted { 7 });
         EXPECT_TRUE(vec.small());
-        EXPECT_EQ(object_count, 2);
+        EXPECT_EQ(object_count, 1);
 
         vec.reserve(8);
         EXPECT_FALSE(vec.small());
         EXPECT_GE(vec.capacity(), 8);
         EXPECT_EQ(vec.size(), 1);
-        EXPECT_EQ(object_count, 3);
+        EXPECT_EQ(object_count, 1);
         EXPECT_EQ(vec[0].value, 7);
     }
     EXPECT_EQ(object_count, 0);
@@ -582,7 +582,7 @@ TEST(Small_Vector, reserve_no_op)
         vec.reserve(2);
         EXPECT_TRUE(vec.small());
         EXPECT_EQ(vec.capacity(), 4);
-        EXPECT_EQ(object_count, 4);
+        EXPECT_EQ(object_count, 2);
         EXPECT_EQ(vec[0].value, 1);
         EXPECT_EQ(vec[1].value, 2);
     }
@@ -625,7 +625,7 @@ TEST(Small_Vector, insert_to_dynamic_storage)
         EXPECT_FALSE(vec.small());
         EXPECT_EQ(vec.size(), 3);
         EXPECT_GE(vec.capacity(), 4);
-        EXPECT_EQ(object_count, 6);
+        EXPECT_EQ(object_count, 4);
         EXPECT_EQ(vec[0].value, 9);
         EXPECT_EQ(vec[1].value, 1);
         EXPECT_EQ(vec[2].value, 2);
@@ -648,7 +648,7 @@ TEST(Small_Vector, insert_dynamic_growth)
         EXPECT_FALSE(vec.small());
         EXPECT_EQ(vec.size(), 5);
         EXPECT_EQ(vec.capacity(), 8);
-        EXPECT_EQ(object_count, 9);
+        EXPECT_EQ(object_count, 7);
         EXPECT_EQ(vec[0].value, 1);
         EXPECT_EQ(vec[1].value, 4);
         EXPECT_EQ(vec[2].value, 5);
@@ -728,7 +728,7 @@ TEST(Small_Vector, swap_both_small)
         EXPECT_EQ(vec2.size(), 2);
         EXPECT_TRUE(vec1.small());
         EXPECT_TRUE(vec2.small());
-        EXPECT_EQ(object_count, 8);
+        EXPECT_EQ(object_count, 3);
         EXPECT_EQ(vec1[0].value, 9);
         EXPECT_EQ(vec2[0].value, 1);
         EXPECT_EQ(vec2[1].value, 2);
@@ -753,7 +753,7 @@ TEST(Small_Vector, swap_both_small_reverse)
         EXPECT_EQ(vec2.size(), 1);
         EXPECT_TRUE(vec1.small());
         EXPECT_TRUE(vec2.small());
-        EXPECT_EQ(object_count, 8);
+        EXPECT_EQ(object_count, 4);
         EXPECT_EQ(vec1[0].value, 2);
         EXPECT_EQ(vec1[1].value, 3);
         EXPECT_EQ(vec1[2].value, 4);
@@ -782,7 +782,7 @@ TEST(Small_Vector, swap_both_dynamic)
         EXPECT_EQ(vec2.size(), 3);
         EXPECT_FALSE(vec1.small());
         EXPECT_FALSE(vec2.small());
-        EXPECT_EQ(object_count, 11);
+        EXPECT_EQ(object_count, 7);
         EXPECT_EQ(vec1[0].value, 4);
         EXPECT_EQ(vec1[3].value, 7);
         EXPECT_EQ(vec2[0].value, 1);
@@ -808,7 +808,7 @@ TEST(Small_Vector, swap_small_dynamic)
         EXPECT_EQ(vec2.size(), 1);
         EXPECT_FALSE(vec1.small());
         EXPECT_TRUE(vec2.small());
-        EXPECT_EQ(object_count, 7);
+        EXPECT_EQ(object_count, 4);
         EXPECT_EQ(vec1[0].value, 2);
         EXPECT_EQ(vec1[2].value, 4);
         EXPECT_EQ(vec2[0].value, 1);
@@ -833,7 +833,7 @@ TEST(Small_Vector, swap_dynamic_small)
         EXPECT_EQ(vec2.size(), 3);
         EXPECT_TRUE(vec1.small());
         EXPECT_FALSE(vec2.small());
-        EXPECT_EQ(object_count, 7);
+        EXPECT_EQ(object_count, 4);
         EXPECT_EQ(vec1[0].value, 4);
         EXPECT_EQ(vec2[0].value, 1);
         EXPECT_EQ(vec2[2].value, 3);
@@ -853,7 +853,7 @@ TEST(Small_Vector, swap_self)
         vec.swap(vec);
         EXPECT_EQ(vec.size(), 2);
         EXPECT_TRUE(vec.small());
-        EXPECT_EQ(object_count, 4);
+        EXPECT_EQ(object_count, 2);
         EXPECT_EQ(vec[0].value, 1);
         EXPECT_EQ(vec[1].value, 2);
     }
@@ -878,7 +878,7 @@ TEST(Small_Vector, free_swap_function)
         EXPECT_EQ(vec2.size(), 1);
         EXPECT_TRUE(vec1.small());
         EXPECT_TRUE(vec2.small());
-        EXPECT_EQ(object_count, 8);
+        EXPECT_EQ(object_count, 3);
         EXPECT_EQ(vec1[0].value, 2);
         EXPECT_EQ(vec1[1].value, 3);
         EXPECT_EQ(vec2[0].value, 1);
@@ -899,7 +899,7 @@ TEST(Small_Vector, iterators)
         EXPECT_EQ(vec.cend() - vec.cbegin(), 2);
         EXPECT_EQ(&*vec.begin(), &vec[0]);
         EXPECT_EQ(&*vec.cbegin(), &vec[0]);
-        EXPECT_EQ(object_count, 4);
+        EXPECT_EQ(object_count, 2);
         EXPECT_EQ(vec.begin()->value, 1);
     }
     EXPECT_EQ(object_count, 0);
@@ -919,7 +919,7 @@ TEST(Small_Vector, iterators_dynamic)
         EXPECT_EQ(vec.cend() - vec.cbegin(), 3);
         EXPECT_EQ(&*vec.begin(), &vec[0]);
         EXPECT_EQ(&*vec.cbegin(), &vec[0]);
-        EXPECT_EQ(object_count, 5);
+        EXPECT_EQ(object_count, 3);
         EXPECT_EQ(vec.begin()->value, 1);
     }
     EXPECT_EQ(object_count, 0);
@@ -938,7 +938,7 @@ TEST(Small_Vector, const_iterators)
         EXPECT_EQ(cvec.end() - cvec.begin(), 2);
         EXPECT_EQ(cvec.cend() - cvec.cbegin(), 2);
         EXPECT_EQ(&*cvec.begin(), &cvec[0]);
-        EXPECT_EQ(object_count, 4);
+        EXPECT_EQ(object_count, 2);
         EXPECT_EQ(cvec.begin()->value, 1);
     }
     EXPECT_EQ(object_count, 0);
@@ -953,7 +953,7 @@ TEST(Small_Vector, allocator_constructor)
         EXPECT_EQ(vec.size(), 0);
         EXPECT_TRUE(vec.empty());
         EXPECT_TRUE(vec.small());
-        EXPECT_EQ(object_count, 4);
+        EXPECT_EQ(object_count, 0);
     }
     EXPECT_EQ(object_count, 0);
 }
@@ -965,7 +965,7 @@ TEST(Small_Vector, get_allocator)
         Small_Vector<Counted, 4> vec;
         void(vec.get_allocator());
         EXPECT_TRUE(vec.small());
-        EXPECT_EQ(object_count, 4);
+        EXPECT_EQ(object_count, 0);
     }
     EXPECT_EQ(object_count, 0);
 }
@@ -984,14 +984,14 @@ TEST(Small_Vector, multiple_growths)
         vec.push_back(Counted { 3 });
         EXPECT_FALSE(vec.small());
         EXPECT_EQ(vec.capacity(), 4);
-        EXPECT_EQ(object_count, 5);
+        EXPECT_EQ(object_count, 3);
 
         vec.push_back(Counted { 4 });
         vec.push_back(Counted { 5 });
         EXPECT_EQ(vec.size(), 5);
         EXPECT_EQ(vec.capacity(), 8);
         EXPECT_FALSE(vec.small());
-        EXPECT_EQ(object_count, 7);
+        EXPECT_EQ(object_count, 5);
         EXPECT_EQ(vec[0].value, 1);
         EXPECT_EQ(vec[4].value, 5);
     }
@@ -1015,7 +1015,7 @@ TEST(Small_Vector, grow_with_existing_allocation)
         EXPECT_FALSE(vec.small());
         EXPECT_EQ(vec.capacity(), 4);
         EXPECT_EQ(vec.size(), 3);
-        EXPECT_EQ(object_count, 5);
+        EXPECT_EQ(object_count, 3);
         EXPECT_EQ(vec[0].value, 1);
         EXPECT_EQ(vec[1].value, 2);
         EXPECT_EQ(vec[2].value, 4);
@@ -1033,13 +1033,13 @@ TEST(Small_Vector, resize_to_zero)
         vec.push_back(Counted { 3 });
         EXPECT_EQ(vec.size(), 3);
         EXPECT_TRUE(vec.small());
-        EXPECT_EQ(object_count, 4);
+        EXPECT_EQ(object_count, 3);
 
         vec.resize(0);
         EXPECT_EQ(vec.size(), 0);
         EXPECT_TRUE(vec.empty());
         EXPECT_TRUE(vec.small());
-        EXPECT_EQ(object_count, 4);
+        EXPECT_EQ(object_count, 0);
     }
     EXPECT_EQ(object_count, 0);
 }
@@ -1054,12 +1054,12 @@ TEST(Small_Vector, resize_shrink_small)
         vec.push_back(Counted { 3 });
         EXPECT_EQ(vec.size(), 3);
         EXPECT_TRUE(vec.small());
-        EXPECT_EQ(object_count, 4);
+        EXPECT_EQ(object_count, 3);
 
         vec.resize(1);
         EXPECT_EQ(vec.size(), 1);
         EXPECT_TRUE(vec.small());
-        EXPECT_EQ(object_count, 4);
+        EXPECT_EQ(object_count, 1);
         EXPECT_EQ(vec[0].value, 1);
     }
     EXPECT_EQ(object_count, 0);
@@ -1077,12 +1077,12 @@ TEST(Small_Vector, resize_shrink_dynamic)
         vec.push_back(Counted { 5 });
         EXPECT_EQ(vec.size(), 5);
         EXPECT_FALSE(vec.small());
-        EXPECT_EQ(object_count, 7);
+        EXPECT_EQ(object_count, 5);
 
         vec.resize(2);
         EXPECT_EQ(vec.size(), 2);
         EXPECT_FALSE(vec.small());
-        EXPECT_EQ(object_count, 4);
+        EXPECT_EQ(object_count, 2);
         EXPECT_EQ(vec[0].value, 1);
         EXPECT_EQ(vec[1].value, 2);
     }
@@ -1097,12 +1097,12 @@ TEST(Small_Vector, resize_grow_within_small)
         vec.push_back(Counted { 1 });
         EXPECT_EQ(vec.size(), 1);
         EXPECT_TRUE(vec.small());
-        EXPECT_EQ(object_count, 4);
+        EXPECT_EQ(object_count, 1);
 
         vec.resize(3);
         EXPECT_EQ(vec.size(), 3);
         EXPECT_TRUE(vec.small());
-        EXPECT_EQ(object_count, 4);
+        EXPECT_EQ(object_count, 3);
         EXPECT_EQ(vec[0].value, 1);
         EXPECT_EQ(vec[1].value, 0);
         EXPECT_EQ(vec[2].value, 0);
@@ -1118,13 +1118,13 @@ TEST(Small_Vector, resize_grow_to_dynamic)
         vec.push_back(Counted { 1 });
         EXPECT_EQ(vec.size(), 1);
         EXPECT_TRUE(vec.small());
-        EXPECT_EQ(object_count, 2);
+        EXPECT_EQ(object_count, 1);
 
         vec.resize(5);
         EXPECT_EQ(vec.size(), 5);
         EXPECT_FALSE(vec.small());
         EXPECT_GE(vec.capacity(), 5);
-        EXPECT_EQ(object_count, 7);
+        EXPECT_EQ(object_count, 5);
         EXPECT_EQ(vec[0].value, 1);
         EXPECT_EQ(vec[1].value, 0);
         EXPECT_EQ(vec[2].value, 0);
@@ -1144,13 +1144,13 @@ TEST(Small_Vector, resize_grow_dynamic)
         vec.push_back(Counted { 3 });
         EXPECT_EQ(vec.size(), 3);
         EXPECT_FALSE(vec.small());
-        EXPECT_EQ(object_count, 5);
+        EXPECT_EQ(object_count, 3);
 
         vec.resize(6);
         EXPECT_EQ(vec.size(), 6);
         EXPECT_FALSE(vec.small());
         EXPECT_GE(vec.capacity(), 6);
-        EXPECT_EQ(object_count, 8);
+        EXPECT_EQ(object_count, 6);
         EXPECT_EQ(vec[0].value, 1);
         EXPECT_EQ(vec[1].value, 2);
         EXPECT_EQ(vec[2].value, 3);
@@ -1170,35 +1170,20 @@ TEST(Small_Vector, resize_same_size)
         vec.push_back(Counted { 2 });
         EXPECT_EQ(vec.size(), 2);
         EXPECT_TRUE(vec.small());
-        EXPECT_EQ(object_count, 4);
+        EXPECT_EQ(object_count, 2);
 
         vec.resize(2);
         EXPECT_EQ(vec.size(), 2);
         EXPECT_TRUE(vec.small());
-        EXPECT_EQ(object_count, 4);
+        EXPECT_EQ(object_count, 2);
         EXPECT_EQ(vec[0].value, 1);
         EXPECT_EQ(vec[1].value, 2);
     }
     EXPECT_EQ(object_count, 0);
 }
 
-consteval int f()
-{
-    Small_Vector<int, 16> v;
-    v.push_back(1);
-    v.push_back(2);
-    v.push_back(3);
-    COWEL_ASSERT(v[0] == 1);
-    COWEL_ASSERT(v[1] == 2);
-    COWEL_ASSERT(v[2] == 3);
-
-    auto x = v;
-    return 0;
-}
-
 [[maybe_unused]]
-constexpr int x
-    = f();
+constexpr Small_Vector<std::string, 4> empty;
 
 } // namespace
 } // namespace cowel


### PR DESCRIPTION
This change makes it so that Small_Vector can no longer be used to hold elements during constant evaluation, but an empty container can still be created, even as a constexpr variable. The benefit is that this removes the need for default-constructible element types.

Also, some default constructors that only existed for the purpose of storing elements in Small_Vector were removed, such as that on File_Source_Span.